### PR TITLE
Add SDK crates to Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[workspace]
+members = [
+  "sgx_alloc",
+  "sgx_rand",
+  "sgx_rand_derive",
+  "sgx_serialize",
+  "sgx_serialize_derive",
+  "sgx_serialize_derive_internals",
+  "sgx_tcrypto",
+  "sgx_tdh",
+  "sgx_tkey_exchange",
+  "sgx_tprotected_fs",
+  "sgx_trts",
+  "sgx_tse",
+  "sgx_tseal",
+  "sgx_tservice",
+  "sgx_tstd",
+  "sgx_tunittest",
+  "sgx_types",
+  "sgx_urts",
+]


### PR DESCRIPTION
This makes it easy to use `rust-sgx-sdk` crates as a git dependency:

```toml
sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk" }
sgx_trts = { git = "https://github.com/baidu/rust-sgx-sdk" }
```