### PR TITLE
Explicitly allow unwinding when panicking

### DIFF
--- a/sgx_tstd/src/panicking.rs
+++ b/sgx_tstd/src/panicking.rs
@@ -127,7 +127,7 @@ extern {
                                 data: *mut u8,
                                 data_ptr: *mut usize,
                                 vtable_ptr: *mut usize) -> u32;
-    #[unwind]
+    #[unwind(allowed)]
     fn __rust_start_panic(data: usize, vtable: usize) -> u32;
 }
 
@@ -275,7 +275,7 @@ pub fn panicking() -> bool {
 
 /// Entry point of panic from the libcore crate.
 #[lang = "panic_fmt"]
-#[unwind]
+#[unwind(allowed)]
 pub extern fn rust_begin_panic(msg: fmt::Arguments,
                                file: &'static str,
                                line: u32,


### PR DESCRIPTION
This PR allows compilation using nightly `rustc`. As per `rustc --explain E0633`, `allowed` is already the default; this just squelches the error by making it explicit.