### PR TITLE
Fix panic payload propagation

### DIFF
--- a/sgx_tstd/src/panicking.rs
+++ b/sgx_tstd/src/panicking.rs
@@ -397,10 +397,11 @@ fn rust_panic_with_hook(payload: &mut BoxMeUp,
     }
 
     {
-        let info = PanicInfo::internal_constructor(
+        let mut info = PanicInfo::internal_constructor(
             message,
-			Location::internal_constructor(file, line, col),
+            Location::internal_constructor(file, line, col),
         );
+        info.set_payload(payload.get());
         panic_handler(&info);
     }
 


### PR DESCRIPTION
Updated to match [rustc stdlib](https://github.com/rust-lang/rust/blob/d41f21f11/src/libstd/panicking.rs#L475)