### PR TITLE
Use `core::ffi::c_void` instead of reimplementing

### DIFF
--- a/sgx_types/src/lib.rs
+++ b/sgx_types/src/lib.rs
@@ -38,14 +38,7 @@
 #[macro_use]
 mod macros;
 
-#[repr(u8)]
-pub enum c_void {
-    // Two dummy variants so the #[repr] attribute can be used.
-    #[doc(hidden)]
-    __variant1,
-    #[doc(hidden)]
-    __variant2,
-}
+pub use core::ffi::c_void;
 
 pub type int8_t = i8;
 pub type int16_t = i16;


### PR DESCRIPTION
We made an equivalent change in our project. It seems to work fine. I thought I would send upstream. Let me know what you think. Thanks!