### PR TITLE
Use `core::mem::zeroed` to get a zero-initialized struct

### DIFF
--- a/sgx_types/src/types.rs
+++ b/sgx_types/src/types.rs
@@ -27,7 +27,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use core::default::Default;
-use core::mem::transmute;
 use error::*;
 use marker::ContiguousMemory;
 
@@ -1092,7 +1091,7 @@ pub struct sgx_uswitchless_config_t {
 
 impl Default for sgx_uswitchless_config_t {
     fn default() -> sgx_uswitchless_config_t {
-        let mut config: sgx_uswitchless_config_t = unsafe{ transmute([0u8; 56]) };
+        let mut config: sgx_uswitchless_config_t = unsafe{ core::mem::zeroed() };
         config.num_uworkers = 1;
         config.num_tworkers = 1;
         config


### PR DESCRIPTION
Instead of `mem::transmute`

The struct `sgx_uswitchless_config_t` contains a function pointer,
so it's size may vary by implementation. The previous implementation
for zeroing it used `transmute` with an array of fixed size.

This implementation is correct for `x86_64` but `sgx_types` may
also be used outside the enclave, for instance it is dependended on
by `sgx_urts`. This change improves portability, and readability.