### PR TITLE
Fix ucd-generate lazy_static dep

### DIFF
--- a/third_party/ucd-generate/ucd-parse/Cargo.toml
+++ b/third_party/ucd-generate/ucd-parse/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["unicode", "database", "character", "property"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-lazy_static = { path = "../../lazy-static.rs" }
+lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 regex = { path = "../../regex" }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]


### PR DESCRIPTION
This updates the `ucd-generate` third party crate to use mainline `lazy_static` since it's no longer in `third-party`.