### PR TITLE
samplecode/sealeddata Add Vec to RandData and serialize before sealing

### DIFF
--- a/samplecode/sealeddata/enclave/Cargo.toml
+++ b/samplecode/sealeddata/enclave/Cargo.toml
@@ -15,3 +15,6 @@ sgx_types = { path = "../../../sgx_types" }
 sgx_tseal = { path = "../../../sgx_tseal" }
 sgx_tstd = { path = "../../../sgx_tstd" }
 sgx_rand = { path = "../../../sgx_rand" }
+serde = { path = "../../../third_party/serde-rs/serde/serde" }
+serde_derive = { path = "../../../third_party/serde-rs/serde/serde_derive" }
+serde_cbor = { path = "../../../third_party/cbor" }


### PR DESCRIPTION
This adds a `Vec` to `RandData` and serializes the data before sealing.

Caveat: The example does **not** work. The PR is thought as a help to discuss #69, so that Github's code commenting and reviewing functionality can be used.