### PR TITLE
Deprecate std::error::Error::Description

### DIFF
--- a/sgx_tstd/src/error.rs
+++ b/sgx_tstd/src/error.rs
@@ -42,7 +42,10 @@ use core::char;
 /// Base functionality for all errors in Rust.
 pub trait Error: Debug + Display {
     /// A short description of the error.
-    fn description(&self) -> &str;
+    #[deprecated]
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
+    }
 
     /// The lower-level cause of this error, if any.
     fn cause(&self) -> Option<&Error> { None }


### PR DESCRIPTION
[`std::error::Error::description`](https://github.com/rust-lang/rust/blob/master/src/libstd/error.rs#L68-L70) is [deprecated](https://doc.rust-lang.org/std/error/trait.Error.html#method.description). Rust `libstd` allows omitting `description`, but `std_tstd` does not; this PR remedies this.