### PR TITLE
Return the amount of failed tests in rsgx_unit tests

### DIFF
--- a/samplecode/unit-test/app/src/main.rs
+++ b/samplecode/unit-test/app/src/main.rs
@@ -40,7 +40,7 @@ static ENCLAVE_FILE: &'static str = "enclave.signed.so";
 static ENCLAVE_TOKEN: &'static str = "enclave.token";
 
 extern {
-    fn test_main_entrance(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+    fn test_main_entrance(eid: sgx_enclave_id_t, retval: *mut size_t) -> sgx_status_t;
 }
 
 fn init_enclave() -> SgxResult<SgxEnclave> {
@@ -124,7 +124,7 @@ fn main() {
         },
     };
 
-    let mut retval = sgx_status_t::SGX_SUCCESS;
+    let mut retval = 0usize;
 
     let result = unsafe {
         test_main_entrance(enclave.geteid(),
@@ -138,6 +138,7 @@ fn main() {
             return;
         }
     }
+    assert_eq!(retval, 0);
 
     println!("[+] unit_test ended!");
 

--- a/samplecode/unit-test/enclave/Enclave.edl
+++ b/samplecode/unit-test/enclave/Enclave.edl
@@ -39,6 +39,6 @@ enclave {
     trusted {
         /* define ECALLs here. */
 
-        public sgx_status_t test_main_entrance();
+        public size_t test_main_entrance();
     };
 };

--- a/samplecode/unit-test/enclave/src/lib.rs
+++ b/samplecode/unit-test/enclave/src/lib.rs
@@ -94,7 +94,7 @@ use test_types::*;
 
 #[no_mangle]
 pub extern "C"
-fn test_main_entrance() -> sgx_status_t {
+fn test_main_entrance() -> size_t {
     rsgx_unit_tests!(
                      // tcrypto
                      test_rsgx_sha256_slice,
@@ -159,7 +159,6 @@ fn test_main_entrance() -> sgx_status_t {
                      // types
                      check_metadata_size,
                      check_version
-                     );
-    sgx_status_t::SGX_SUCCESS
+                     )
 }
 

--- a/sgx_tunittest/src/lib.rs
+++ b/sgx_tunittest/src/lib.rs
@@ -134,7 +134,8 @@ macro_rules! should_panic {
 ///
 /// `rsgx_unit_tests!` works as a variadic function. It takes a list of test
 /// case function as arguments and then execute them sequentially. It prints
-/// the statistics on the test result at the end.
+/// the statistics on the test result at the end, and returns the amount of
+/// failed tests. meaning if everything works the return vlaue will be 0.
 ///
 /// One test fails if and only if it panics. For fail test (similar to
 /// `#[should_panic]` in Rust, one should wrap the line which would panic with
@@ -184,6 +185,7 @@ pub fn rsgx_unit_test_start () {
 ///
 /// `rsgx_unit_test_end` prints the statistics on test result, including
 /// a list of failed tests and the statistics.
+/// It will return the amount of failed tests. (success == 0)
 pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) -> usize {
     let ntotal = ntestcases as usize;
     let nsucc  = ntestcases as usize - failurecases.len();

--- a/sgx_tunittest/src/lib.rs
+++ b/sgx_tunittest/src/lib.rs
@@ -161,11 +161,13 @@ macro_rules! rsgx_unit_tests {
     (
         $($f : path),*
     ) => {
-        rsgx_unit_test_start();
-        let mut ntestcases : u64 = 0u64;
-        let mut failurecases : Vec<String> = Vec::new();
-        $(rsgx_unit_test(&mut ntestcases, &mut failurecases, $f,stringify!($f));)*
-        rsgx_unit_test_end(ntestcases, failurecases);
+        {
+            rsgx_unit_test_start();
+            let mut ntestcases : u64 = 0u64;
+            let mut failurecases : Vec<String> = Vec::new();
+            $(rsgx_unit_test(&mut ntestcases, &mut failurecases, $f,stringify!($f));)*
+            rsgx_unit_test_end(ntestcases, failurecases)
+        }
     }
 }
 
@@ -182,15 +184,14 @@ pub fn rsgx_unit_test_start () {
 ///
 /// `rsgx_unit_test_end` prints the statistics on test result, including
 /// a list of failed tests and the statistics.
-pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) {
+pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) -> usize {
     let ntotal = ntestcases as usize;
     let nsucc  = ntestcases as usize - failurecases.len();
 
     if failurecases.len() != 0{
-        let vfailures = failurecases;
         print!("\nfailures: ");
         println!("    {}",
-                 vfailures.iter()
+                 failurecases.iter()
                           .fold(
                               String::new(),
                               |s, per| s + "\n    " + per));
@@ -203,6 +204,7 @@ pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) {
     }
 
     println!("{} tested, {} passed, {} failed", ntotal, nsucc, ntotal - nsucc);
+    failurecases.len()
 }
 
 /// Perform one test case at a time.


### PR DESCRIPTION
resolves #82 

- I made `rsgx_unit_test_end`/`rsgx_unit_tests! ` return the amount of failed tests.
- Edited unit-test samplecode to return this value through the edl and `assert_eq` to zero.