### PR TITLE
add some gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ Cargo.lock
 *_u.h
 *_t.c
 *_t.h
+
+#build file
+**/bin/app
+**/target
+
+#third party
+third_party/ring/pregenerated/


### PR DESCRIPTION
#99 
I run the `make` command in `hello-rust`,`helloworld` and `ue-ra`, I found I forget the following files:
```
	samplecode/hello-rust/app/target/
	samplecode/hello-rust/bin/app
	samplecode/hello-rust/enclave/target/
	samplecode/helloworld/bin/app
	samplecode/helloworld/enclave/target/
	samplecode/mutual-ra/app/target/
	samplecode/mutual-ra/bin/app
	samplecode/mutual-ra/enclave/target/
	samplecode/ue-ra/ue-ra-client/target/
	samplecode/ue-ra/ue-ra-server/app/target/
	samplecode/ue-ra/ue-ra-server/bin/app
	samplecode/ue-ra/ue-ra-server/enclave/target/
	third_party/ring/pregenerated/
```
Sorry!