### PR TITLE
Changing the `rsgx_unit_tests` to accept experssions

### DIFF
--- a/sgx_tunittest/Cargo.toml
+++ b/sgx_tunittest/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"
 description = "Rust SGX SDK provides the ability to write Intel SGX applications in Rust Programming Language."
+edition = "2018"
 
 include = [
     "LICENSE",

--- a/sgx_tunittest/src/lib.rs
+++ b/sgx_tunittest/src/lib.rs
@@ -160,7 +160,7 @@ macro_rules! should_panic {
 #[macro_export]
 macro_rules! rsgx_unit_tests {
     (
-        $($f : expr),*
+        $($f : expr),* $(,)?
     ) => {
         {
             rsgx_unit_test_start();

--- a/sgx_tunittest/src/lib.rs
+++ b/sgx_tunittest/src/lib.rs
@@ -160,7 +160,7 @@ macro_rules! should_panic {
 #[macro_export]
 macro_rules! rsgx_unit_tests {
     (
-        $($f : path),*
+        $($f : expr),*
     ) => {
         {
             rsgx_unit_test_start();


### PR DESCRIPTION
Hi,
Sorry for the change again (and only a day after the last release :/ )

but I think this makes the macro more versatile.
You can see here that `rsgx_unit_tests_before` doesn't compile and `rsgx_unit_tests_after` does.
https://play.rust-lang.org/?gist=b6e853576b51f7033866368506c5c522

Thanks!
CC #65