### PR TITLE
Strict untrusted version for ue-ra-client sample

### DIFF
--- a/samplecode/ue-ra/ue-ra-client/Cargo.toml
+++ b/samplecode/ue-ra/ue-ra-client/Cargo.toml
@@ -10,7 +10,7 @@ rustls      = { version = "0.13.0", features = ["dangerous_configuration"] }
 itertools   = "*"
 sgx_types   = { rev = "v1.0.8", git = "https://github.com/baidu/rust-sgx-sdk" }
 base64      = "0.9.2"
-untrusted   = "*"
+untrusted   = "0.6.2"
 serde_json  = "1.0.24"
 num-bigint  = "*"
 bit-vec     = "*"


### PR DESCRIPTION
webpki 0.18.1 depends on untrusted 0.6.2, but Cargo resolved 0.7.0 on build, that lead to build failure.

It is strange Cargo doesn't resolve `webpki`'s dependencies

here's an output of `cargo tree` (Already strict `untrusted` version)

```
ue-ra-client v0.1.0 (/home/jasl/Workspaces/rust-sgx-sdk/samplecode/ue-ra/ue-ra-client)
├── base64 v0.9.3
│   ├── byteorder v1.3.2
│   └── safemem v0.3.0
├── bit-vec v0.6.1
├── chrono v0.4.7
│   ├── libc v0.2.60
│   ├── num-integer v0.1.41
│   │   └── num-traits v0.2.8
│   │       [build-dependencies]
│   │       └── autocfg v0.1.5
│   │   [build-dependencies]
│   │   └── autocfg v0.1.5 (*)
│   ├── num-traits v0.2.8 (*)
│   └── time v0.1.42
│       └── libc v0.2.60 (*)
│       [dev-dependencies]
│       └── winapi v0.3.7
├── hex v0.3.2
├── itertools v0.8.0
│   └── either v1.5.2
├── num-bigint v0.2.2
│   ├── num-integer v0.1.41 (*)
│   └── num-traits v0.2.8 (*)
├── rustls v0.13.1
│   ├── base64 v0.9.3 (*)
│   ├── log v0.4.7
│   │   └── cfg-if v0.1.9
│   ├── ring v0.13.5
│   │   ├── lazy_static v1.3.0
│   │   ├── libc v0.2.60 (*)
│   │   └── untrusted v0.6.2
│   │   [build-dependencies]
│   │   └── cc v1.0.37
│   ├── sct v0.4.0
│   │   ├── ring v0.13.5 (*)
│   │   └── untrusted v0.6.2 (*)
│   ├── untrusted v0.6.2 (*)
│   └── webpki v0.18.1
│       ├── ring v0.13.5 (*)
│       └── untrusted v0.6.2 (*)
│   [dev-dependencies]
│   └── log v0.4.7 (*)
├── serde_json v1.0.40
│   ├── itoa v0.4.4
│   ├── ryu v1.0.0
│   └── serde v1.0.97
├── sgx_types v1.0.8 (https://github.com/baidu/rust-sgx-sdk?rev=v1.0.8#bc2d7e24)
├── untrusted v0.6.2 (*)
└── webpki v0.18.1 (*)
```