### PR TITLE
fix tlsserver bug

### DIFF
--- a/samplecode/tls/tlsserver/app/src/main.rs
+++ b/samplecode/tls/tlsserver/app/src/main.rs
@@ -412,7 +412,7 @@ impl Connection {
             self.do_tls_write();
         }
 
-        if self.closing && !self.wants_write() {
+        if self.closing {
             self.tls_close();
             let _ = self.socket.shutdown(Shutdown::Both);
             self.close_back();


### PR DESCRIPTION
[CVE-2019-15541](https://nvd.nist.gov/vuln/detail/CVE-2019-15541)

rustls-mio/examples/tlsserver.rs in the rustls crate before 0.16.0 for Rust allows attackers to cause a denial of service (loop of conn_event and ready) by arranging for a client to never be writable.