### PR TITLE
Don't gitignore committed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,16 +12,12 @@ Cargo.lock
 *.so.*
 
 #generated proxy
-*_u.c
-*_u.h
-*_t.c
-*_t.h
+samplecode/**/*_u.c
+samplecode/**/*_u.h
+samplecode/**/*_t.c
+samplecode/**/*_t.h
 
 **/target
-
-#generated sample files
-samplecode/**/target
-#samplecode/**/bin/*[!md]
 
 #generated assembly
 third_party/ring/pregenerated
@@ -37,8 +33,7 @@ bazel-testlogs
 #libunwind
 sgx_unwind/libunwind/INSTALL
 sgx_unwind/libunwind/config/*
-sgx_unwind/libunwind/include/*.in
-sgx_unwind/libunwind/include/config.h.*
+sgx_unwind/libunwind/include/config.h.in~
 sgx_unwind/libunwind/Makefile.in
 sgx_unwind/libunwind/aclocal.m4
 sgx_unwind/libunwind/autom4te.cache/*


### PR DESCRIPTION
A couple of files are being gitignored even though they have been committed:

```bash
$ git ls-files -i --exclude-standard
mesalock-rt/libprotobuf.so.9
mesalock-rt/libsgx_uae_service.so
mesalock-rt/libsgx_urts.so
mesalock-rt/libstdc++.so.6
mesalock-rt/libz.so.1
samplecode/psi/SMCClient/sample_libcrypto/libsample_libcrypto.so
samplecode/remoteattestation/ServiceProvider/sample_libcrypto/libsample_libcrypto.so
sgx_backtrace_sys/libbacktrace/backtrace_t.h
sgx_unwind/libunwind/include/config.h.in
sgx_unwind/libunwind/include/libunwind-common.h.in
sgx_unwind/libunwind/include/libunwind.h.in
```

Looks like some of these are essential and do need to be tracked:

```bash
sgx_backtrace_sys/libbacktrace/backtrace_t.h
sgx_unwind/libunwind/include/config.h.in
sgx_unwind/libunwind/include/libunwind-common.h.in
sgx_unwind/libunwind/include/libunwind.h.in
```