### PR TITLE
Update sgx_tcrypto_helper to support MesaTEE

### DIFF
--- a/sgx_tcrypto_helper/Cargo.toml
+++ b/sgx_tcrypto_helper/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [lib]
 name = "sgx_tcrypto_helper"
-path = "./src/lib.rs"
 crate-type = ["staticlib","rlib"]
 
 [features]

--- a/sgx_tcrypto_helper/Cargo.toml
+++ b/sgx_tcrypto_helper/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [lib]
 name = "sgx_tcrypto_helper"
-path = "../sgx_crypto_helper/src/lib.rs"
+path = "./src/lib.rs"
 crate-type = ["staticlib","rlib"]
 
 [features]

--- a/sgx_tcrypto_helper/Readme.md
+++ b/sgx_tcrypto_helper/Readme.md
@@ -2,16 +2,4 @@
 
 Please visit our [homepage](https://github.com/apache/teaclave-sgx-sdk) for usage. Thanks!
 
-# sgx_tcrypto_helper
-
-This crate intended to be the corresponding crate of sgx_crypto_helper works in SGX enclave. It shares the source codes with sgx_crypto_helper but with different dependencies. To use this crate, you can add the following lines to your Cargo.toml:
-
-```
-sgx_crypto_helper = { package="sgx_tcrypto_helper", git = "https://github.com/apache/teaclave-sgx-sdk" }
-```
-
-And then
-
-```
-extern crate sgx_crypto_helper; // same to sgx_crypto_helper!
-```
+This crate intended to be the corresponding crate of sgx_crypto_helper works in the SGX enclave. The source codes are the same to sgx_crypto_helper. And the dependencies in Cargo.toml are different.

--- a/sgx_tcrypto_helper/src/lib.rs
+++ b/sgx_tcrypto_helper/src/lib.rs
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License..
+
+//! # Cryptography Library Helper
+//!
+//! This crate provides helper functions to simplify key distribution and
+//! encryption/decryption. It utilizes sgx_tcrypto and sgx_ucrypto to provide
+//! a uniform interface to both enclave and untrusted app. It provides key
+//! serialization/deserialization by serde.
+//!
+//! The Intel(R) Software Guard Extensions SDK includes a trusted cryptography
+//! library named sgx_tcrypto. It includes the cryptographic functions used by
+//! other trusted libraries included in the SDK.
+//!
+
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(clippy::too_many_arguments)]
+
+#![cfg_attr(all(feature = "mesalock_sgx", not(target_env = "sgx")), no_std)]
+#![cfg_attr(target_env = "sgx", feature(rustc_private))]
+#![cfg_attr(test, feature(test))]
+
+#[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+extern crate sgx_types;
+#[cfg(any(feature = "mesalock_sgx", target_env = "sgx"))]
+extern crate sgx_tcrypto as crypto;
+#[cfg(not(any(feature = "mesalock_sgx", target_env = "sgx")))]
+extern crate sgx_ucrypto as crypto;
+
+use std::prelude::v1::*;
+use sgx_types::SgxResult;
+use crypto::SgxRsaPrivKey;
+use crypto::SgxRsaPubKey;
+
+/// A trait to express the ability to create a RSA keypair with default e
+/// (65537) or customized e, and to_privkey/to_pubkey, encryption/decryption API.
+pub trait RsaKeyPair {
+    /// Create a new RSA keypair with default e = 65537.
+    fn new() -> SgxResult<Self> where Self: std::marker::Sized;
+    /// Create a new RSA keypair with customized e
+    fn new_with_e(e: u32) -> SgxResult<Self> where Self: std::marker::Sized;
+    /// Get a private key instance typed `SgxRsaPrivKey` which is defined in sgx_tcrypto/sgx_ucrypto.
+    fn to_privkey(self) -> SgxResult<SgxRsaPrivKey>;
+    /// get a public key instance typed `SgxPubPrivKey` which is defined in sgx_tcrypto/sgx_ucrypto.
+    fn to_pubkey(self) -> SgxResult<SgxRsaPubKey>;
+    /// Encrypt a u8 slice to a Vec<u8>. Returns the length of ciphertext if OK.
+    fn encrypt_buffer(self, plaintext: &[u8], ciphertext: &mut Vec<u8>) -> SgxResult<usize>;
+    /// Decrypt a u8 slice to a Vec<u8>. Returns the length of plaintext if OK.
+    fn decrypt_buffer(self, ciphertext: &[u8], plaintext: &mut Vec<u8>) -> SgxResult<usize>;
+}
+
+extern crate serde;
+extern crate serde_derive;
+extern crate itertools;
+#[macro_use]
+extern crate serde_big_array;
+
+pub mod rsa2048;
+pub mod rsa3072;

--- a/sgx_tcrypto_helper/src/lib.rs
+++ b/sgx_tcrypto_helper/src/lib.rs
@@ -18,8 +18,8 @@
 //! # Cryptography Library Helper
 //!
 //! This crate provides helper functions to simplify key distribution and
-//! encryption/decryption. It utilizes sgx_tcrypto and sgx_ucrypto to provide
-//! a uniform interface to both enclave and untrusted app. It provides key
+//! encryption/decryption. It utilizes sgx_tcrypto to provide
+//! a interface to enclave app. It provides key
 //! serialization/deserialization by serde.
 //!
 //! The Intel(R) Software Guard Extensions SDK includes a trusted cryptography

--- a/sgx_tcrypto_helper/src/rsa2048.rs
+++ b/sgx_tcrypto_helper/src/rsa2048.rs
@@ -1,3 +1,28 @@
+u// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License..
+
+//! # Cryptography Library Helper
+//!
+//! This crate provides helper functions to simplify key distribution and
+//! encryption/decryption. It utilizes sgx_tcrypto to provide
+//! a interface to enclave app. It provides key
+//! serialization/deserialization by serde.
+//!
+
 use crypto::rsgx_create_rsa_key_pair;
 use crypto::{SgxRsaPrivKey, SgxRsaPubKey};
 use itertools::Itertools;

--- a/sgx_tcrypto_helper/src/rsa2048.rs
+++ b/sgx_tcrypto_helper/src/rsa2048.rs
@@ -1,0 +1,447 @@
+use crypto::rsgx_create_rsa_key_pair;
+use crypto::{SgxRsaPrivKey, SgxRsaPubKey};
+use itertools::Itertools;
+use sgx_types::{sgx_status_t, size_t, SgxResult};
+pub const SGX_RSA2048_KEY_SIZE: size_t     = 256;
+pub const SGX_RSA2048_PRI_EXP_SIZE: size_t = 256;
+pub const SGX_RSA2048_PUB_EXP_SIZE: size_t = 4;
+pub const SGX_RSA2048_DEFAULT_E: [u8;SGX_RSA2048_PUB_EXP_SIZE]    = [0x01, 0x00, 0x00, 0x01]; // 65537
+use std::fmt;
+
+use std::prelude::v1::*;
+use crate::RsaKeyPair;
+use serde_derive::*;
+
+big_array! { BigArray; }
+
+/// Data structure of RSA 2048 Keypair (RSA-OAEP).
+/// RSA 2048 Keypair provides block cipher encryption/decryption
+/// implementations. The block size of plain text is 190 bytes
+/// and the block size of cipher text is 256 bytes.
+/// 190 byte = 2048bit - 2*SHA256_BYTE - 2
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct Rsa2048KeyPair {
+    #[serde(with = "BigArray")]
+    n: [u8; SGX_RSA2048_KEY_SIZE],
+    #[serde(with = "BigArray")]
+    d: [u8; SGX_RSA2048_PRI_EXP_SIZE],
+    e: [u8; SGX_RSA2048_PUB_EXP_SIZE],
+    #[serde(with = "BigArray")]
+    p: [u8; SGX_RSA2048_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    q: [u8; SGX_RSA2048_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    dmp1: [u8; SGX_RSA2048_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    dmq1: [u8; SGX_RSA2048_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    iqmp: [u8; SGX_RSA2048_KEY_SIZE / 2],
+}
+
+impl Default for Rsa2048KeyPair {
+    fn default() -> Self {
+        Rsa2048KeyPair {
+            n: [0; SGX_RSA2048_KEY_SIZE],
+            d: [0; SGX_RSA2048_PRI_EXP_SIZE],
+            e: SGX_RSA2048_DEFAULT_E,
+            p: [0; SGX_RSA2048_KEY_SIZE / 2],
+            q: [0; SGX_RSA2048_KEY_SIZE / 2],
+            dmp1: [0; SGX_RSA2048_KEY_SIZE / 2],
+            dmq1: [0; SGX_RSA2048_KEY_SIZE / 2],
+            iqmp: [0; SGX_RSA2048_KEY_SIZE / 2],
+        }
+    }
+}
+
+impl fmt::Debug for Rsa2048KeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#"Rsa2048KeyPair: {{ n:{:02X}, d:{:02X}, e:{:02X}, p:{:02X}, q:{:02X}, dmp1:{:02X}, dmq:{:02X}, iqmp:{:02X} }}"#,
+            self.n.iter().format(""),
+            self.d.iter().format(""),
+            self.e.iter().format(""),
+            self.p.iter().format(""),
+            self.q.iter().format(""),
+            self.dmp1.iter().format(""),
+            self.dmq1.iter().format(""),
+            self.iqmp.iter().format(""))
+    }
+}
+
+impl RsaKeyPair for Rsa2048KeyPair {
+    fn new() -> SgxResult<Self> {
+        let mut newkey = Self::default();
+        match rsgx_create_rsa_key_pair(
+            SGX_RSA2048_KEY_SIZE as i32,
+            SGX_RSA2048_PUB_EXP_SIZE as i32,
+            &mut newkey.n,
+            &mut newkey.d,
+            &mut newkey.e,
+            &mut newkey.p,
+            &mut newkey.q,
+            &mut newkey.dmp1,
+            &mut newkey.dmq1,
+            &mut newkey.iqmp,
+        ) {
+            Ok(()) => Ok(newkey),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn new_with_e(e: u32) -> SgxResult<Self> {
+        let mut newkey = Self::default();
+        newkey.e = e.to_le_bytes();
+        match rsgx_create_rsa_key_pair(
+            SGX_RSA2048_KEY_SIZE as i32,
+            SGX_RSA2048_PUB_EXP_SIZE as i32,
+            &mut newkey.n,
+            &mut newkey.d,
+            &mut newkey.e,
+            &mut newkey.p,
+            &mut newkey.q,
+            &mut newkey.dmp1,
+            &mut newkey.dmq1,
+            &mut newkey.iqmp,
+        ) {
+            Ok(()) => Ok(newkey),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn to_privkey(self) -> SgxResult<SgxRsaPrivKey> {
+        let result = SgxRsaPrivKey::new();
+        match result.create(
+            SGX_RSA2048_KEY_SIZE as i32,
+            SGX_RSA2048_PRI_EXP_SIZE as i32,
+            &self.e,
+            &self.p,
+            &self.q,
+            &self.dmp1,
+            &self.dmq1,
+            &self.iqmp,
+        ) {
+            Ok(()) => Ok(result),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn to_pubkey(self) -> SgxResult<SgxRsaPubKey> {
+        let result = SgxRsaPubKey::new();
+        match result.create(
+            SGX_RSA2048_KEY_SIZE as i32,
+            SGX_RSA2048_PUB_EXP_SIZE as i32,
+            &self.n,
+            &self.e,
+        ) {
+            Ok(()) => Ok(result),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn encrypt_buffer(self, plaintext: &[u8], ciphertext: &mut Vec<u8>) -> SgxResult<usize> {
+        let pubkey = self.to_pubkey()?;
+        let bs = 256;
+
+        // The magic number 190 comes from RSA-OAEP:
+        // #define RSA_2048_KEY_BYTE    256
+        // #define SHA_SIZE_BIT         256
+        // #define RSAOAEP_ENCRYPT_MAXLEN RSA_2048_KEY_BYTE - 2*SHA_SIZE_BIT/8 - 2 /* 190 */
+        // RSA_2048_KEY_BYTE - 2*SHA_SIZE_BIT/8 - 2
+        let bs_plain = bs - 2 * 256 / 8 - 2;
+        let count = (plaintext.len() + bs_plain - 1) / bs_plain;
+        ciphertext.resize(bs * count, 0);
+
+        for i in 0..count {
+            let cipher_slice = &mut ciphertext[i * bs..i * bs + bs];
+            let mut out_len = bs;
+            let plain_slice =
+                &plaintext[i * bs_plain..std::cmp::min(i * bs_plain + bs_plain, plaintext.len())];
+
+            pubkey.encrypt_sha256(cipher_slice, &mut out_len, plain_slice)?;
+        }
+
+        Ok(ciphertext.len())
+    }
+
+    fn decrypt_buffer(self, ciphertext: &[u8], plaintext: &mut Vec<u8>) -> SgxResult<usize> {
+        let privkey = self.to_privkey()?;
+        let bs = 256;
+        if ciphertext.len() % bs != 0 {
+            return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER);
+        }
+        // The magic number 190 comes from RSA-OAEP:
+        // #define RSA_2048_KEY_BYTE    256
+        // #define SHA_SIZE_BIT         256
+        // #define RSAOAEP_ENCRYPT_MAXLEN RSA_2048_KEY_BYTE - 2*SHA_SIZE_BIT/8 - 2 /* 190 */
+        // RSA_2048_KEY_BYTE - 2*SHA_SIZE_BIT/8 - 2
+        //let bs_plain = 256 - 2 * 256 / 8 - 2;
+        let bs_plain = bs;
+        let count = ciphertext.len() / bs;
+        plaintext.clear();
+
+        for i in 0..count {
+            let cipher_slice = &ciphertext[i * bs..i * bs + bs];
+            let plain_slice = &mut vec![0;bs_plain];
+            let mut plain_len = bs_plain;
+
+            privkey.decrypt_sha256(plain_slice, &mut plain_len, cipher_slice)?;
+            let mut decoded_vec = plain_slice[..plain_len].to_vec();
+            plaintext.append(&mut decoded_vec);
+        }
+
+        Ok(plaintext.len())
+    }
+
+}
+
+impl Rsa2048KeyPair {
+    pub fn export_pubkey(self) -> SgxResult<Rsa2048PubKey> {
+        Ok(Rsa2048PubKey {
+            n: self.n,
+            e: self.e,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct Rsa2048PubKey {
+    #[serde(with = "BigArray")]
+    n: [u8; SGX_RSA2048_KEY_SIZE],
+    e: [u8; SGX_RSA2048_PUB_EXP_SIZE],
+}
+
+impl Default for Rsa2048PubKey {
+    fn default() -> Self {
+        Rsa2048PubKey {
+            n: [0; SGX_RSA2048_KEY_SIZE],
+            e: SGX_RSA2048_DEFAULT_E,
+        }
+    }
+}
+
+impl Rsa2048PubKey {
+    pub fn to_pubkey(self) -> SgxResult<SgxRsaPubKey> {
+        let result = SgxRsaPubKey::new();
+        match result.create(
+            SGX_RSA2048_KEY_SIZE as i32,
+            SGX_RSA2048_PUB_EXP_SIZE as i32,
+            &self.n,
+            &self.e,
+        ) {
+            Ok(()) => Ok(result),
+            Err(x) => Err(x),
+        }
+    }
+
+    pub fn encrypt_buffer(self, plaintext: &[u8], ciphertext: &mut Vec<u8>) -> SgxResult<usize> {
+        let pubkey = self.to_pubkey()?;
+        let bs = 256;
+
+        // The magic number 190 comes from RSA-OAEP:
+        // #define RSA_2048_KEY_BYTE    256
+        // #define SHA_SIZE_BIT         256
+        // #define RSAOAEP_ENCRYPT_MAXLEN RSA_2048_KEY_BYTE - 2*SHA_SIZE_BIT/8 - 2 /* 190 */
+        // RSA_2048_KEY_BYTE - 2*SHA_SIZE_BIT/8 - 2
+        let bs_plain = bs - 2 * 256 / 8 - 2;
+        let count = (plaintext.len() + bs_plain - 1) / bs_plain;
+        ciphertext.resize(bs * count, 0);
+
+        for i in 0..count {
+            let cipher_slice = &mut ciphertext[i * bs..i * bs + bs];
+            let mut out_len = bs;
+            let plain_slice =
+                &plaintext[i * bs_plain..std::cmp::min(i * bs_plain + bs_plain, plaintext.len())];
+
+            pubkey.encrypt_sha256(cipher_slice, &mut out_len, plain_slice)?;
+        }
+
+        Ok(ciphertext.len())
+    }
+}
+
+impl fmt::Debug for Rsa2048PubKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#"Rsa2048KeyPair: {{ n:{:02X}, e:{:02X} }}"#,
+            self.n.iter().format(""),
+            self.e.iter().format(""))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    extern crate rdrand;
+    extern crate rand_core;
+    extern crate test;
+
+    use self::rdrand::RdRand;
+    use self::rand_core::RngCore;
+    use crate::RsaKeyPair;
+    use crate::rsa2048::Rsa2048KeyPair;
+    use crate::rsa2048::Rsa2048PubKey;
+    use crate::rsa2048::SgxRsaPrivKey;
+    use crate::rsa2048::SgxRsaPubKey;
+    use crypto::rsgx_create_rsa_key_pair;
+    use sgx_types::sgx_status_t;
+    use self::test::Bencher;
+
+    #[test]
+    fn rsa2048_new() {
+        let keypair = Rsa2048KeyPair::new();
+        assert!(keypair.is_ok());
+        let keypair = Rsa2048KeyPair::new_with_e(3);
+        assert!(keypair.is_ok());
+        let keypair = Rsa2048KeyPair::new_with_e(65537);
+        assert!(keypair.is_ok());
+    }
+
+    #[test]
+    fn rsa2048_new_fail() {
+        let keypair = Rsa2048KeyPair::new_with_e(4);
+        assert_eq!(keypair.unwrap_err(), sgx_status_t::SGX_ERROR_UNEXPECTED);
+        let keypair = Rsa2048KeyPair::new_with_e(65536);
+        assert_eq!(keypair.unwrap_err(), sgx_status_t::SGX_ERROR_UNEXPECTED); }
+
+    #[test]
+    fn rsa2048_to_sgx_rsa_pub_key() {
+        let keypair = Rsa2048KeyPair::default();
+        assert!(keypair.to_pubkey().is_err());
+        let keypair = Rsa2048KeyPair::new().unwrap();
+        assert!(keypair.to_pubkey().is_ok());
+        let keypair = Rsa2048KeyPair::new_with_e(3).unwrap();
+        assert!(keypair.to_pubkey().is_ok());
+        let keypair = Rsa2048KeyPair::new_with_e(65537).unwrap();
+        assert!(keypair.to_pubkey().is_ok());
+    }
+
+    #[test]
+    fn rsa2048_to_sgx_rsa_priv_key() {
+        let keypair = Rsa2048KeyPair::default();
+        assert!(keypair.to_privkey().is_err());
+        let keypair = Rsa2048KeyPair::new().unwrap();
+        assert!(keypair.to_privkey().is_ok());
+        let keypair = Rsa2048KeyPair::new_with_e(3).unwrap();
+        assert!(keypair.to_privkey().is_ok());
+        let keypair = Rsa2048KeyPair::new_with_e(65537).unwrap();
+        assert!(keypair.to_privkey().is_ok());
+    }
+
+    #[test]
+    fn rsa_encrypt_decrypt() {
+        let text = String::from("abc");
+        let text_slice = &text.into_bytes();
+
+        let mod_size: i32 = 256;
+        let exp_size: i32 = 4;
+        let mut n: Vec<u8> = vec![0_u8; mod_size as usize];
+        let mut d: Vec<u8> = vec![0_u8; mod_size as usize];
+        let mut e: Vec<u8> = vec![1, 0, 1, 0];
+        let mut p: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut q: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut dmp1: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut dmq1: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut iqmp: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+
+        assert!(rsgx_create_rsa_key_pair(
+            mod_size,
+            exp_size,
+            n.as_mut_slice(),
+            d.as_mut_slice(),
+            e.as_mut_slice(),
+            p.as_mut_slice(),
+            q.as_mut_slice(),
+            dmp1.as_mut_slice(),
+            dmq1.as_mut_slice(),
+            iqmp.as_mut_slice()
+        )
+        .is_ok());
+
+        let privkey = SgxRsaPrivKey::new();
+        let pubkey = SgxRsaPubKey::new();
+
+        assert!(pubkey
+            .create(mod_size, exp_size, n.as_slice(), e.as_slice())
+            .is_ok());
+
+        assert!(privkey
+            .create(
+                mod_size,
+                exp_size,
+                e.as_slice(),
+                p.as_slice(),
+                q.as_slice(),
+                dmp1.as_slice(),
+                dmq1.as_slice(),
+                iqmp.as_slice()
+            )
+            .is_ok());
+
+        let mut ciphertext: Vec<u8> = vec![0_u8; 256];
+        let mut chipertext_len: usize = ciphertext.len();
+        assert!(pubkey
+            .encrypt_sha256(ciphertext.as_mut_slice(), &mut chipertext_len, text_slice)
+            .is_ok());
+
+        let mut plaintext: Vec<u8> = vec![0_u8; 256];
+        let mut plaintext_len: usize = plaintext.len();
+        assert!(privkey
+            .decrypt_sha256(
+                plaintext.as_mut_slice(),
+                &mut plaintext_len,
+                ciphertext.as_slice()
+            )
+            .is_ok());
+
+        assert_eq!(plaintext[..plaintext_len], text_slice[..])
+    }
+
+    #[test]
+    fn buffer_enc_dec() {
+        let plaintext: Vec<u8> = "A".repeat(1000).into_bytes();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        let kp = Rsa2048KeyPair::new().unwrap();
+        assert!(kp.encrypt_buffer(&plaintext, &mut ciphertext).is_ok());
+        let mut decrypted: Vec<u8> = Vec::new();
+        assert!(kp.decrypt_buffer(&ciphertext, &mut decrypted).is_ok());
+        assert_eq!("A".repeat(1000), String::from_utf8(decrypted).unwrap());
+    }
+
+    #[test]
+    fn export_test() {
+        let plaintext: Vec<u8> = "T".repeat(1000).into_bytes();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        let kp = Rsa2048KeyPair::new().unwrap();
+        let exported_pub_key = kp.export_pubkey();
+        assert!(exported_pub_key.is_ok());
+
+        let exported_pub_key = exported_pub_key.unwrap();
+        let serialized_pub_key = serde_json::to_string(&exported_pub_key).unwrap();
+        let deserialized_pub_key: Rsa2048PubKey = serde_json::from_str(&serialized_pub_key).unwrap();
+
+        assert!(deserialized_pub_key.encrypt_buffer(&plaintext, &mut ciphertext).is_ok());
+        let mut decrypted: Vec<u8> = Vec::new();
+        assert!(kp.decrypt_buffer(&ciphertext, &mut decrypted).is_ok());
+        assert_eq!("T".repeat(1000), String::from_utf8(decrypted).unwrap());
+    }
+
+    #[bench]
+    fn encrypt_speed_bench(b: &mut Bencher) {
+        let mut rng = RdRand::new().unwrap();
+        let mut buffer = vec![0;1*1024*1024];
+        let kp = Rsa2048KeyPair::new().unwrap();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        rng.fill_bytes(&mut buffer);
+        b.iter(|| kp.encrypt_buffer(&buffer, &mut ciphertext));
+    }
+
+    #[bench]
+    fn decrypt_speed_bench(b: &mut Bencher) {
+        let mut rng = RdRand::new().unwrap();
+        let mut buffer = vec![0;1*1024*1024];
+        let kp = Rsa2048KeyPair::new().unwrap();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        rng.fill_bytes(&mut buffer);
+        kp.encrypt_buffer(&buffer, &mut ciphertext).unwrap();
+        let mut decrypted: Vec<u8> = Vec::new();
+        b.iter(|| kp.decrypt_buffer(&ciphertext, &mut decrypted));
+    }
+}

--- a/sgx_tcrypto_helper/src/rsa2048.rs
+++ b/sgx_tcrypto_helper/src/rsa2048.rs
@@ -1,4 +1,4 @@
-u// Licensed to the Apache Software Foundation (ASF) under one
+// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/sgx_tcrypto_helper/src/rsa3072.rs
+++ b/sgx_tcrypto_helper/src/rsa3072.rs
@@ -1,3 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License..
+
+//! # Cryptography Library Helper
+//!
+//! This crate provides helper functions to simplify key distribution and
+//! encryption/decryption. It utilizes sgx_tcrypto to provide
+//! a interface to enclave app. It provides key
+//! serialization/deserialization by serde.
+//!
+
 use crypto::rsgx_create_rsa_key_pair;
 use crypto::{SgxRsaPrivKey, SgxRsaPubKey};
 use itertools::Itertools;

--- a/sgx_tcrypto_helper/src/rsa3072.rs
+++ b/sgx_tcrypto_helper/src/rsa3072.rs
@@ -1,0 +1,436 @@
+use crypto::rsgx_create_rsa_key_pair;
+use crypto::{SgxRsaPrivKey, SgxRsaPubKey};
+use itertools::Itertools;
+use sgx_types::sgx_status_t;
+use sgx_types::SgxResult;
+use sgx_types::{SGX_RSA3072_KEY_SIZE, SGX_RSA3072_PRI_EXP_SIZE, SGX_RSA3072_PUB_EXP_SIZE};
+pub const SGX_RSA3072_DEFAULT_E: [u8;SGX_RSA3072_PUB_EXP_SIZE]    = [0x01, 0x00, 0x00, 0x01]; // 65537
+use std::fmt;
+
+use std::prelude::v1::*;
+use crate::RsaKeyPair;
+use serde_derive::*;
+
+big_array! { BigArray; }
+
+/// Data structure of RSA 3072 Keypair (RSA-OAEP).
+/// RSA 3072 Keypair provides block cipher encryption/decryption
+/// implementations. The block size of plain text is 318 bytes
+/// and the block size of cipher text is 256 bytes.
+/// 318 byte = 3072bit - 2*SHA256_BYTE -2
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct Rsa3072KeyPair {
+    #[serde(with = "BigArray")]
+    n: [u8; SGX_RSA3072_KEY_SIZE],
+    #[serde(with = "BigArray")]
+    d: [u8; SGX_RSA3072_PRI_EXP_SIZE],
+    e: [u8; SGX_RSA3072_PUB_EXP_SIZE],
+    #[serde(with = "BigArray")]
+    p: [u8; SGX_RSA3072_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    q: [u8; SGX_RSA3072_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    dmp1: [u8; SGX_RSA3072_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    dmq1: [u8; SGX_RSA3072_KEY_SIZE / 2],
+    #[serde(with = "BigArray")]
+    iqmp: [u8; SGX_RSA3072_KEY_SIZE / 2],
+}
+
+impl Default for Rsa3072KeyPair {
+    fn default() -> Self {
+        Rsa3072KeyPair {
+            n: [0; SGX_RSA3072_KEY_SIZE],
+            d: [0; SGX_RSA3072_PRI_EXP_SIZE],
+            e: SGX_RSA3072_DEFAULT_E,
+            p: [0; SGX_RSA3072_KEY_SIZE / 2],
+            q: [0; SGX_RSA3072_KEY_SIZE / 2],
+            dmp1: [0; SGX_RSA3072_KEY_SIZE / 2],
+            dmq1: [0; SGX_RSA3072_KEY_SIZE / 2],
+            iqmp: [0; SGX_RSA3072_KEY_SIZE / 2],
+        }
+    }
+}
+
+impl fmt::Debug for Rsa3072KeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#"Rsa3072KeyPair: {{ n:{:02X}, d:{:02X}, e:{:02X}, p:{:02X}, q:{:02X}, dmp1:{:02X}, dmq:{:02X}, iqmp:{:02X} }}"#,
+            self.n.iter().format(""),
+            self.d.iter().format(""),
+            self.e.iter().format(""),
+            self.p.iter().format(""),
+            self.q.iter().format(""),
+            self.dmp1.iter().format(""),
+            self.dmq1.iter().format(""),
+            self.iqmp.iter().format(""))
+    }
+}
+
+impl RsaKeyPair for Rsa3072KeyPair {
+    fn new() -> SgxResult<Self> {
+        let mut newkey = Self::default();
+        match rsgx_create_rsa_key_pair(
+            SGX_RSA3072_KEY_SIZE as i32,
+            SGX_RSA3072_PUB_EXP_SIZE as i32,
+            &mut newkey.n,
+            &mut newkey.d,
+            &mut newkey.e,
+            &mut newkey.p,
+            &mut newkey.q,
+            &mut newkey.dmp1,
+            &mut newkey.dmq1,
+            &mut newkey.iqmp,
+        ) {
+            Ok(()) => Ok(newkey),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn new_with_e(e: u32) -> SgxResult<Self> {
+        let mut newkey = Self::default();
+        newkey.e = e.to_le_bytes();
+        match rsgx_create_rsa_key_pair(
+            SGX_RSA3072_KEY_SIZE as i32,
+            SGX_RSA3072_PUB_EXP_SIZE as i32,
+            &mut newkey.n,
+            &mut newkey.d,
+            &mut newkey.e,
+            &mut newkey.p,
+            &mut newkey.q,
+            &mut newkey.dmp1,
+            &mut newkey.dmq1,
+            &mut newkey.iqmp,
+        ) {
+            Ok(()) => Ok(newkey),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn to_privkey(self) -> SgxResult<SgxRsaPrivKey> {
+        let result = SgxRsaPrivKey::new();
+        match result.create(
+            SGX_RSA3072_KEY_SIZE as i32,
+            SGX_RSA3072_PRI_EXP_SIZE as i32,
+            &self.e,
+            &self.p,
+            &self.q,
+            &self.dmp1,
+            &self.dmq1,
+            &self.iqmp,
+        ) {
+            Ok(()) => Ok(result),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn to_pubkey(self) -> SgxResult<SgxRsaPubKey> {
+        let result = SgxRsaPubKey::new();
+        match result.create(
+            SGX_RSA3072_KEY_SIZE as i32,
+            SGX_RSA3072_PUB_EXP_SIZE as i32,
+            &self.n,
+            &self.e,
+        ) {
+            Ok(()) => Ok(result),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn encrypt_buffer(self, plaintext: &[u8], ciphertext: &mut Vec<u8>) -> SgxResult<usize> {
+        let pubkey = self.to_pubkey()?;
+        let bs = 384;
+
+        let bs_plain = bs - 2 * 256 / 8 - 2;
+        let count = (plaintext.len() + bs_plain - 1) / bs_plain;
+        ciphertext.resize(bs * count, 0);
+
+        for i in 0..count {
+            let cipher_slice = &mut ciphertext[i * bs..i * bs + bs];
+            let mut out_len = bs;
+            let plain_slice =
+                &plaintext[i * bs_plain..std::cmp::min(i * bs_plain + bs_plain, plaintext.len())];
+
+            pubkey.encrypt_sha256(cipher_slice, &mut out_len, plain_slice)?;
+        }
+
+        Ok(ciphertext.len())
+    }
+
+    fn decrypt_buffer(self, ciphertext: &[u8], plaintext: &mut Vec<u8>) -> SgxResult<usize> {
+        let privkey = self.to_privkey()?;
+        let bs = 384;
+
+        if ciphertext.len() % bs != 0 {
+            return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER);
+        }
+
+        // Additional one byte is required in 1.0.9
+        // let bs_plain = bs - 2 * 256 / 8 - 2;
+        // In 2.6, we need a longer buf to put the decrypted data.
+        // The output length is exactly bs_plain above, but it results in
+        // SGX_ERROR_INVALID_PARAMETER.
+        let bs_plain = bs;
+        let count = ciphertext.len() / bs;
+        plaintext.clear();
+
+        for i in 0..count {
+            let cipher_slice = &ciphertext[i * bs..i * bs + bs];
+            let plain_slice = &mut vec![0;bs_plain];
+            let mut plain_len = bs_plain;
+
+            privkey.decrypt_sha256(plain_slice, &mut plain_len, cipher_slice)?;
+            let mut decoded_vec = plain_slice[..plain_len].to_vec();
+            plaintext.append(&mut decoded_vec);
+        }
+
+        Ok(plaintext.len())
+    }
+}
+
+impl Rsa3072KeyPair {
+    pub fn export_pubkey(self) -> SgxResult<Rsa3072PubKey> {
+        Ok(Rsa3072PubKey {
+            n: self.n,
+            e: self.e,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct Rsa3072PubKey {
+    #[serde(with = "BigArray")]
+    n: [u8; SGX_RSA3072_KEY_SIZE],
+    e: [u8; SGX_RSA3072_PUB_EXP_SIZE],
+}
+
+impl Default for Rsa3072PubKey {
+    fn default() -> Self {
+        Rsa3072PubKey {
+            n: [0; SGX_RSA3072_KEY_SIZE],
+            e: SGX_RSA3072_DEFAULT_E,
+        }
+    }
+}
+
+impl Rsa3072PubKey {
+    fn to_pubkey(self) -> SgxResult<SgxRsaPubKey> {
+        let result = SgxRsaPubKey::new();
+        match result.create(
+            SGX_RSA3072_KEY_SIZE as i32,
+            SGX_RSA3072_PUB_EXP_SIZE as i32,
+            &self.n,
+            &self.e,
+        ) {
+            Ok(()) => Ok(result),
+            Err(x) => Err(x),
+        }
+    }
+
+    pub fn encrypt_buffer(self, plaintext: &[u8], ciphertext: &mut Vec<u8>) -> SgxResult<usize> {
+        let pubkey = self.to_pubkey()?;
+        let bs = 384;
+
+        let bs_plain = bs - 2 * 256 / 8 - 2;
+        let count = (plaintext.len() + bs_plain - 1) / bs_plain;
+        ciphertext.resize(bs * count, 0);
+
+        for i in 0..count {
+            let cipher_slice = &mut ciphertext[i * bs..i * bs + bs];
+            let mut out_len = bs;
+            let plain_slice =
+                &plaintext[i * bs_plain..std::cmp::min(i * bs_plain + bs_plain, plaintext.len())];
+
+            pubkey.encrypt_sha256(cipher_slice, &mut out_len, plain_slice)?;
+        }
+
+        Ok(ciphertext.len())
+    }
+}
+
+impl fmt::Debug for Rsa3072PubKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#"Rsa3072KeyPair: {{ n:{:02X}, e:{:02X} }}"#,
+            self.n.iter().format(""),
+            self.e.iter().format(""))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate rdrand;
+    extern crate rand_core;
+    extern crate test;
+
+    use self::test::Bencher;
+    use self::rdrand::RdRand;
+    use self::rand_core::RngCore;
+    use crate::RsaKeyPair;
+    use crate::rsa3072::Rsa3072KeyPair;
+    use crate::rsa3072::Rsa3072PubKey;
+    use crate::rsa3072::SgxRsaPrivKey;
+    use crate::rsa3072::SgxRsaPubKey;
+    use crypto::rsgx_create_rsa_key_pair;
+    use sgx_types::sgx_status_t;
+
+    #[test]
+    fn rsa3072_new() {
+        let keypair = Rsa3072KeyPair::new();
+        assert!(keypair.is_ok());
+        let keypair = Rsa3072KeyPair::new_with_e(3);
+        assert!(keypair.is_ok());
+        let keypair = Rsa3072KeyPair::new_with_e(65537);
+        assert!(keypair.is_ok());
+    }
+
+    #[test]
+    fn rsa3072_new_fail() {
+        let keypair = Rsa3072KeyPair::new_with_e(4);
+        assert_eq!(keypair.unwrap_err(), sgx_status_t::SGX_ERROR_UNEXPECTED);
+        let keypair = Rsa3072KeyPair::new_with_e(65536);
+        assert_eq!(keypair.unwrap_err(), sgx_status_t::SGX_ERROR_UNEXPECTED);
+    }
+
+    #[test]
+    fn rsa3072_to_sgx_rsa_pub_key() {
+        let keypair = Rsa3072KeyPair::default();
+        assert!(keypair.to_pubkey().is_err());
+        let keypair = Rsa3072KeyPair::new().unwrap();
+        assert!(keypair.to_pubkey().is_ok());
+        let keypair = Rsa3072KeyPair::new_with_e(3).unwrap();
+        assert!(keypair.to_pubkey().is_ok());
+        let keypair = Rsa3072KeyPair::new_with_e(65537).unwrap();
+        assert!(keypair.to_pubkey().is_ok());
+    }
+
+    #[test]
+    fn rsa3072_to_sgx_rsa_priv_key() {
+        let keypair = Rsa3072KeyPair::default();
+        assert!(keypair.to_privkey().is_err());
+        let keypair = Rsa3072KeyPair::new().unwrap();
+        assert!(keypair.to_privkey().is_ok());
+        let keypair = Rsa3072KeyPair::new_with_e(3).unwrap();
+        assert!(keypair.to_privkey().is_ok());
+        let keypair = Rsa3072KeyPair::new_with_e(65537).unwrap();
+        assert!(keypair.to_privkey().is_ok());
+    }
+
+    #[test]
+    fn rsa_encrypt_decrypt() {
+        let text = String::from("abc");
+        let text_slice = &text.into_bytes();
+
+        let mod_size: i32 = 256;
+        let exp_size: i32 = 4;
+        let mut n: Vec<u8> = vec![0_u8; mod_size as usize];
+        let mut d: Vec<u8> = vec![0_u8; mod_size as usize];
+        let mut e: Vec<u8> = vec![1, 0, 1, 0];
+        let mut p: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut q: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut dmp1: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut dmq1: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+        let mut iqmp: Vec<u8> = vec![0_u8; mod_size as usize / 2];
+
+        assert!(rsgx_create_rsa_key_pair(
+            mod_size,
+            exp_size,
+            n.as_mut_slice(),
+            d.as_mut_slice(),
+            e.as_mut_slice(),
+            p.as_mut_slice(),
+            q.as_mut_slice(),
+            dmp1.as_mut_slice(),
+            dmq1.as_mut_slice(),
+            iqmp.as_mut_slice()
+        )
+        .is_ok());
+
+        let privkey = SgxRsaPrivKey::new();
+        let pubkey = SgxRsaPubKey::new();
+
+        assert!(pubkey
+            .create(mod_size, exp_size, n.as_slice(), e.as_slice())
+            .is_ok());
+
+        assert!(privkey
+            .create(
+                mod_size,
+                exp_size,
+                e.as_slice(),
+                p.as_slice(),
+                q.as_slice(),
+                dmp1.as_slice(),
+                dmq1.as_slice(),
+                iqmp.as_slice()
+            )
+            .is_ok());
+
+        let mut ciphertext: Vec<u8> = vec![0_u8; 256];
+        let mut chipertext_len: usize = ciphertext.len();
+        assert!(pubkey
+            .encrypt_sha256(ciphertext.as_mut_slice(), &mut chipertext_len, text_slice)
+            .is_ok());
+
+        let mut plaintext: Vec<u8> = vec![0_u8; 256];
+        let mut plaintext_len: usize = plaintext.len();
+        assert!(privkey
+            .decrypt_sha256(
+                plaintext.as_mut_slice(),
+                &mut plaintext_len,
+                ciphertext.as_slice()
+            )
+            .is_ok());
+
+        assert_eq!(plaintext[..plaintext_len], text_slice[..])
+    }
+
+    #[test]
+    fn buffer_enc_dec() {
+        let plaintext: Vec<u8> = "A".repeat(1000).into_bytes();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        let kp = Rsa3072KeyPair::new().unwrap();
+        assert!(kp.encrypt_buffer(&plaintext, &mut ciphertext).is_ok());
+        let mut decrypted: Vec<u8> = Vec::new();
+        assert!(kp.decrypt_buffer(&ciphertext, &mut decrypted).is_ok());
+        assert_eq!("A".repeat(1000), String::from_utf8(decrypted).unwrap());
+    }
+
+    #[test]
+    fn export_test() {
+        let plaintext: Vec<u8> = "T".repeat(1000).into_bytes();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        let kp = Rsa3072KeyPair::new().unwrap();
+        let exported_pub_key = kp.export_pubkey();
+        assert!(exported_pub_key.is_ok());
+
+        let exported_pub_key = exported_pub_key.unwrap();
+        let serialized_pub_key = serde_json::to_string(&exported_pub_key).unwrap();
+        let deserialized_pub_key: Rsa3072PubKey = serde_json::from_str(&serialized_pub_key).unwrap();
+
+        assert!(deserialized_pub_key.encrypt_buffer(&plaintext, &mut ciphertext).is_ok());
+        let mut decrypted: Vec<u8> = Vec::new();
+        assert!(kp.decrypt_buffer(&ciphertext, &mut decrypted).is_ok());
+        assert_eq!("T".repeat(1000), String::from_utf8(decrypted).unwrap());
+    }
+
+    #[bench]
+    fn encrypt_speed_bench(b: &mut Bencher) {
+        let mut rng = RdRand::new().unwrap();
+        let mut buffer = vec![0;1*1024*1024];
+        let kp = Rsa3072KeyPair::new().unwrap();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        rng.fill_bytes(&mut buffer);
+        b.iter(|| kp.encrypt_buffer(&buffer, &mut ciphertext));
+    }
+
+    #[bench]
+    fn decrypt_speed_bench(b: &mut Bencher) {
+        let mut rng = RdRand::new().unwrap();
+        let mut buffer = vec![0;1*1024*1024];
+        let kp = Rsa3072KeyPair::new().unwrap();
+        let mut ciphertext: Vec<u8> = Vec::new();
+        rng.fill_bytes(&mut buffer);
+        kp.encrypt_buffer(&buffer, &mut ciphertext).unwrap();
+        let mut decrypted: Vec<u8> = Vec::new();
+        b.iter(|| kp.decrypt_buffer(&ciphertext, &mut decrypted));
+    }
+}


### PR DESCRIPTION
As talk in this issue: apache/incubator-teaclave#196, I update the tsgx_tcrypto_helper.
The compiling and running result show sgx_tcrypto_helper works fine.