### PR TITLE
Fix xargo compile warning

### DIFF
--- a/sgx_backtrace/src/symbolize/libbacktrace.rs
+++ b/sgx_backtrace/src/symbolize/libbacktrace.rs
@@ -348,7 +348,7 @@ pub fn set_enclave_path(path: &str) -> bool {
         use std::path::Path;
         use std::untrusted::path::PathEx;
         let p: &Path = path.as_ref();
-        if !p.exists() {
+        if !PathEx::exists(p) {
             return false;
         }
     }


### PR DESCRIPTION
Fix xargo compilation sgx_bracktrace warnings by explicitly calling PathEx methods.
warning: unused_imports

Signed-off-by: volcano <volcano_dr@163.com>