### PR TITLE
refactor(sgx_tunittest): remove the necessary 'std::panic' import for 'should_panic' macro

### DIFF
--- a/sgx_tunittest/src/lib.rs
+++ b/sgx_tunittest/src/lib.rs
@@ -105,9 +105,9 @@ use std::vec::Vec;
 /// This requires developer to identify the line which triggers panic exactly.
 #[macro_export]
 macro_rules! should_panic {
-    ($fmt:expr) => ({
-        match panic::catch_unwind( || { $fmt }).is_err() {
-            true => {},
+    ($fmt:expr) => {{
+        match std::panic::catch_unwind(|| $fmt).is_err() {
+            true => {}
             false => {
                 ::std::rt::begin_panic($fmt, {
                     // static requires less code at runtime, more constant data
@@ -116,7 +116,7 @@ macro_rules! should_panic {
                 })
             }
         }
-    });
+    }};
 }
 
 /// This macro works as test case driver.
@@ -166,7 +166,7 @@ macro_rules! rsgx_unit_tests {
 /// To initiate the test environment, `rsgx_unit_tests!` macro would trigger
 /// `rsgx_unit_test_start` at the very beginning. `rsgx_unit_test_start` inits
 /// the test counter and fail test list, and print the prologue message.
-pub fn rsgx_unit_test_start () {
+pub fn rsgx_unit_test_start() {
     println!("\nstart running tests");
 }
 
@@ -175,17 +175,18 @@ pub fn rsgx_unit_test_start () {
 /// `rsgx_unit_test_end` prints the statistics on test result, including
 /// a list of failed tests and the statistics.
 /// It will return the amount of failed tests. (success == 0)
-pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) -> usize {
+pub fn rsgx_unit_test_end(ntestcases: u64, failurecases: Vec<String>) -> usize {
     let ntotal = ntestcases as usize;
-    let nsucc  = ntestcases as usize - failurecases.len();
+    let nsucc = ntestcases as usize - failurecases.len();
 
-    if failurecases.len() != 0{
+    if failurecases.len() != 0 {
         print!("\nfailures: ");
-        println!("    {}",
-                 failurecases.iter()
-                          .fold(
-                              String::new(),
-                              |s, per| s + "\n    " + per));
+        println!(
+            "    {}",
+            failurecases
+                .iter()
+                .fold(String::new(), |s, per| s + "\n    " + per)
+        );
     }
 
     if ntotal == nsucc {
@@ -194,7 +195,12 @@ pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) -> usize
         print!("\ntest result \x1B[1;31mFAILED\x1B[0m. ");
     }
 
-    println!("{} tested, {} passed, {} failed", ntotal, nsucc, ntotal - nsucc);
+    println!(
+        "{} tested, {} passed, {} failed",
+        ntotal,
+        nsucc,
+        ntotal - nsucc
+    );
     failurecases.len()
 }
 
@@ -205,23 +211,22 @@ pub fn rsgx_unit_test_end(ntestcases : u64, failurecases : Vec<String>) -> usize
 /// and on test fails, it records the failed test.
 /// Required test function must be `Fn()`, taking nothing as input and returns
 /// nothing.
-pub fn rsgx_unit_test<F, R>(ncases: &mut u64, failurecases: &mut Vec<String>, f:F, name: &str)
-    where F: FnOnce() -> R + std::panic::UnwindSafe {
+pub fn rsgx_unit_test<F, R>(ncases: &mut u64, failurecases: &mut Vec<String>, f: F, name: &str)
+where
+    F: FnOnce() -> R + std::panic::UnwindSafe,
+{
     *ncases = *ncases + 1;
-    match std::panic::catch_unwind (|| { f(); } ).is_ok() {
+    match std::panic::catch_unwind(|| {
+        f();
+    })
+    .is_ok()
+    {
         true => {
-                  println!("{} {} ... {}!",
-                           "testing",
-                           name,
-                           "\x1B[1;32mok\x1B[0m");
-                },
+            println!("{} {} ... {}!", "testing", name, "\x1B[1;32mok\x1B[0m");
+        }
         false => {
-                  println!("{} {} ... {}!",
-                           "testing",
-                            name,
-                           "\x1B[1;31mfailed\x1B[0m");
-                  failurecases.push(String::from(name));
-        },
+            println!("{} {} ... {}!", "testing", name, "\x1B[1;31mfailed\x1B[0m");
+            failurecases.push(String::from(name));
+        }
     }
 }
-


### PR DESCRIPTION
## Problem

The `should_panic!` macro in `sgx_tunittest` uses `std::panic`, which requires us the imports
`std::panic` every time we use `should_panic!`.

A demo project goes as [patch-sgx_tunittest](https://github.com/sammyne/patch-sgx_tunittest).

To verify, just comment out the patch section of Cargo.toml.

The project demonstrates the this inconvenience, and helps to support [this patch](https://github.com/sammyne/incubator-teaclave-sgx-sdk/commit/34a50a6307b2853d907b3a457cf9c961074f98e0#diff-b02276d3fdf8ec232bd27c1b90221758R109).

The patch mainly add the `std::` prefix to the `panic` function in use so as to avoid explicit
import of the `std::panic` every time.

Hope it helps~

