### PR TITLE
fix sgx_urts  undefined reference to `t_signal_handler_ecall` error

### DIFF
--- a/samplecode/unit-test/app/Cargo.toml
+++ b/samplecode/unit-test/app/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git",  features = ["global_init"] }
+sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git",  features = ["global_init", "signal"] }
 
 [patch.'https://github.com/apache/teaclave-sgx-sdk.git']
 sgx_types = { path = "../../../sgx_types" }

--- a/sgx_urts/Cargo.toml
+++ b/sgx_urts/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["rlib"]
 default = []
 global_init = []
 global_exit = []
+signal = []
 
 
 [dependencies]

--- a/sgx_urts/src/lib.rs
+++ b/sgx_urts/src/lib.rs
@@ -32,6 +32,7 @@ pub mod pipe;
 pub mod event;
 pub mod thread;
 pub mod net;
+#[cfg(feature = "signal")]
 pub mod signal;
 pub mod process;
 pub use enclave::*;

--- a/sgx_urts/src/signal.rs
+++ b/sgx_urts/src/signal.rs
@@ -41,7 +41,7 @@ extern "C" {
 pub struct SigNum(i32);
 
 impl SigNum {
-    // add code here
+
     pub fn from_raw(signo: i32) -> Option<SigNum> {
         if signo <= 0 || signo >= NSIG {
             None
@@ -59,7 +59,7 @@ impl SigNum {
 pub struct SigSet(sigset_t);
 
 impl SigSet {
-    // add code here
+
     pub fn new() -> SigSet {
         let set = unsafe {
             let mut set: sigset_t = mem::zeroed();
@@ -82,7 +82,7 @@ struct GlobalData {
 }
 
 impl GlobalData {
-     // add code here
+
     fn get() -> &'static GlobalData {
         unsafe { GLOBAL_DATA.as_ref().unwrap() }
     }
@@ -101,7 +101,7 @@ struct SignalDispatcher {
 }
 
 impl SignalDispatcher {
-    // add code here
+
     pub fn new () -> SignalDispatcher {
         SignalDispatcher {
             signal_set: Mutex::new(HashMap::new()),


### PR DESCRIPTION
Use signal feature to control compilation of sgx_urts::signal. #234 