### PR TITLE
Fix switchless sample code

### DIFF
--- a/samplecode/switchless/app/src/main.rs
+++ b/samplecode/switchless/app/src/main.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License..
 
+#![feature(link_args)]
+#![link_args = "-Wl,--whole-archive -lsgx_uswitchless -Wl,--no-whole-archive"]
+
 extern crate sgx_types;
 extern crate sgx_urts;
 use sgx_types::*;


### PR DESCRIPTION
In order to use the switchless feature of the SGX, the app binary needs
to be linked with the following flags.

```
-Wl,--whole-archive -lsgx_uswitchless -Wl,--no-whole-archive
````

Noted that there is currently no proper way to pass custom link flags to
all the binaries in a cargo project. As such, the `link_args` macro need
to be set for each of Rust files with `main` methods.

References:

* Build flags used in Intel SGX sample code: https://github.com/intel/linux-sgx/blob/ce4a18d9a0963b14f717cc7462241cfadd233f55/SampleCode/Switchless/Makefile#L104
* Rust tracking issue on `link_args`: https://github.com/rust-lang/rust/issues/29596
* PR for `cargo:rustc-link-arg-bins` in cargo build script: https://github.com/rust-lang/cargo/pull/8441