### PR TITLE
samplecode: fix possible deadlock in db-server

### DIFF
--- a/samplecode/db-proxy/db-server/src/server/mod.rs
+++ b/samplecode/db-proxy/db-server/src/server/mod.rs
@@ -64,7 +64,6 @@ impl server {
 
     fn db_get(&mut self, key: String) -> String {
         let db = self.db_handler.clone();
-        let db_read = db.read();
         let r = db.read().get(key.as_str());
         match r {
             Err(t) => return String::new(),


### PR DESCRIPTION
In samplecode/db-proxy/db-server/src/server/mod.rs:
There are two `db.read()` in fn `fn db_get()`, which may cause deadlock when interleaved by a `db.write()` (e.g. in `db_put()` or `db_delete()`) from another thread.

The fix is to remove the redundant `db.read()`.