### PR TITLE
Add instructions to report security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take a very active stance in eliminating security problems in Teaclave. We
+strongly encourage folks to report such problems to our private mailing list
+first ([private@teaclave.apache.org](mailto:private@teaclave.apache.org)),
+before disclosing them in a public forum.


### PR DESCRIPTION
Add instructions to report security issues.

This file will also be shown as the security policy  in the "Security" section in GitHub.