### PR TITLE
chore(samplecode): init test input for wasmi from makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "samplecode/wasmi/test_input"]
-	path = samplecode/wasmi/test_input
-	url = https://github.com/WebAssembly/testsuite

--- a/samplecode/wasmi/.gitignore
+++ b/samplecode/wasmi/.gitignore
@@ -1,0 +1,1 @@
+/test_input/

--- a/samplecode/wasmi/Makefile
+++ b/samplecode/wasmi/Makefile
@@ -149,7 +149,11 @@ $(Signed_RustEnclave_Name): $(RustEnclave_Name)
 
 .PHONY: enclave
 enclave:
-	(cd ../.. && git submodule init && git submodule update)
+	@if [ ! -d test_input ]; then\
+		git clone https://github.com/WebAssembly/testsuite test_input &&\
+		cd test_input &&\
+		git checkout c6a690f ;\
+	fi
 	$(MAKE) -C ./enclave/
 
 


### PR DESCRIPTION
Remove the git submodule `samplecode/wasmi/test_input` so that it won't be pulled when used as a cargo dependency.