### PR TITLE
Fix mutability of the parameter `ctr` in AES-CTR related functions

### DIFF
--- a/sgx_tcrypto/src/crypto.rs
+++ b/sgx_tcrypto/src/crypto.rs
@@ -1752,7 +1752,7 @@ pub type sgx_aes_ctr_128bit_ctr_t = [uint8_t; SGX_AESCTR_CTR_SIZE];
 pub fn rsgx_aes_ctr_encrypt(
     key: &sgx_aes_ctr_128bit_key_t,
     src: &[u8],
-    ctr: &sgx_aes_ctr_128bit_ctr_t,
+    ctr: &mut sgx_aes_ctr_128bit_ctr_t,
     ctr_inc_bits: u32,
     dst: &mut [u8],
 ) -> SgxError {
@@ -1776,7 +1776,7 @@ pub fn rsgx_aes_ctr_encrypt(
             key as *const sgx_aes_ctr_128bit_key_t,
             src.as_ptr(),
             src_len as u32,
-            ctr as *const sgx_aes_ctr_128bit_ctr_t as *const u8,
+            ctr as *mut sgx_aes_ctr_128bit_ctr_t as *mut u8,
             ctr_inc_bits,
             dst.as_mut_ptr(),
         )
@@ -1848,7 +1848,7 @@ pub fn rsgx_aes_ctr_encrypt(
 pub fn rsgx_aes_ctr_decrypt(
     key: &sgx_aes_ctr_128bit_key_t,
     src: &[u8],
-    ctr: &sgx_aes_ctr_128bit_ctr_t,
+    ctr: &mut sgx_aes_ctr_128bit_ctr_t,
     ctr_inc_bits: u32,
     dst: &mut [u8],
 ) -> SgxError {
@@ -1872,7 +1872,7 @@ pub fn rsgx_aes_ctr_decrypt(
             key as *const sgx_aes_ctr_128bit_key_t,
             src.as_ptr(),
             src.len() as u32,
-            ctr as *const sgx_aes_ctr_128bit_ctr_t as *const u8,
+            ctr as *mut sgx_aes_ctr_128bit_ctr_t as *mut u8,
             ctr_inc_bits,
             dst.as_mut_ptr(),
         )

--- a/sgx_types/src/function.rs
+++ b/sgx_types/src/function.rs
@@ -255,14 +255,14 @@ extern "C" {
     pub fn sgx_aes_ctr_encrypt(p_key: *const sgx_aes_ctr_128bit_key_t,
                                p_src: *const uint8_t,
                                src_len: uint32_t,
-                               p_ctr: *const uint8_t,
+                               p_ctr: *mut uint8_t,
                                ctr_inc_bits: uint32_t,
                                p_dst: *mut uint8_t) -> sgx_status_t;
 
     pub fn sgx_aes_ctr_decrypt(p_key: *const sgx_aes_ctr_128bit_key_t,
                                p_src: *const uint8_t,
                                src_len: uint32_t,
-                               p_ctr: *const uint8_t,
+                               p_ctr: *mut uint8_t,
                                ctr_inc_bits: uint32_t,
                                p_dst: *mut uint8_t) -> sgx_status_t;
 

--- a/sgx_ucrypto/src/crypto.rs
+++ b/sgx_ucrypto/src/crypto.rs
@@ -1602,7 +1602,7 @@ pub type sgx_aes_ctr_128bit_ctr_t = [uint8_t; SGX_AESCTR_CTR_SIZE];
 pub fn rsgx_aes_ctr_encrypt(
     key: &sgx_aes_ctr_128bit_key_t,
     src: &[u8],
-    ctr: &sgx_aes_ctr_128bit_ctr_t,
+    ctr: &mut sgx_aes_ctr_128bit_ctr_t,
     ctr_inc_bits: u32,
     dst: &mut [u8],
 ) -> SgxError {
@@ -1626,7 +1626,7 @@ pub fn rsgx_aes_ctr_encrypt(
             key as *const sgx_aes_ctr_128bit_key_t,
             src.as_ptr(),
             src_len as u32,
-            ctr as *const sgx_aes_ctr_128bit_ctr_t as *const u8,
+            ctr as *mut sgx_aes_ctr_128bit_ctr_t as *mut u8,
             ctr_inc_bits,
             dst.as_mut_ptr(),
         )
@@ -1698,7 +1698,7 @@ pub fn rsgx_aes_ctr_encrypt(
 pub fn rsgx_aes_ctr_decrypt(
     key: &sgx_aes_ctr_128bit_key_t,
     src: &[u8],
-    ctr: &sgx_aes_ctr_128bit_ctr_t,
+    ctr: &mut sgx_aes_ctr_128bit_ctr_t,
     ctr_inc_bits: u32,
     dst: &mut [u8],
 ) -> SgxError {
@@ -1722,7 +1722,7 @@ pub fn rsgx_aes_ctr_decrypt(
             key as *const sgx_aes_ctr_128bit_key_t,
             src.as_ptr(),
             src.len() as u32,
-            ctr as *const sgx_aes_ctr_128bit_ctr_t as *const u8,
+            ctr as *mut sgx_aes_ctr_128bit_ctr_t as *mut u8,
             ctr_inc_bits,
             dst.as_mut_ptr(),
         )


### PR DESCRIPTION
Intel SGX SDK's `sgx_aes_ctr_encrypt` and `sgx_aes_ctr_decrypt` take `uint8_t *p_ctr` as their parameter (instead of `const uint8_t *p_ctr`).
And the counter block will be actually mutated  by these functions during encryption / decryption.
Thus, their wrappers also must take a mutable reference to counter block.