### PR TITLE
force trigger uninit_global_object

### DIFF
--- a/sgx_tstd/src/rt.rs
+++ b/sgx_tstd/src/rt.rs
@@ -17,10 +17,14 @@
 
 //! Runtime services
 
-use sgx_types::sgx_enclave_id_t;
-use crate::enclave;
 use alloc_crate::slice;
 use core::str;
+use crate::enclave;
+use crate::sync::SgxSpinlock;
+use crate::thread;
+use sgx_trts::enclave::rsgx_is_supported_EDMM;
+use sgx_types::{sgx_enclave_id_t, sgx_thread_t, SGX_THREAD_T_NULL};
+
 // Reexport some of our utilities which are expected by other crates.
 pub use crate::panicking::{begin_panic, begin_panic_fmt, update_panic_count};
 pub use crate::sys_common::at_exit;
@@ -28,13 +32,33 @@ use crate::sys_common::cleanup;
 use crate::sync::Once;
 
 static INIT: Once = Once::new();
+static EXIT: Once = Once::new();
+static GLOBAL_INIT_LOCK: SgxSpinlock = SgxSpinlock::new();
+static mut INIT_TCS: sgx_thread_t = SGX_THREAD_T_NULL;
 
 #[no_mangle]
 pub extern "C" fn t_global_exit_ecall() {
+    extern "C" {
+        fn uninit_global_object();
+    }
+
+    GLOBAL_INIT_LOCK.lock();
+    EXIT.call_once(|| {
+        unsafe {
+            if INIT_TCS == thread::rsgx_thread_self() {
+                if !rsgx_is_supported_EDMM() {
+                    uninit_global_object();
+                }
+            }
+        }
+    });
 }
 
 #[no_mangle]
 pub extern "C" fn t_global_init_ecall(id: u64, path: *const u8, len: usize) {
+    GLOBAL_INIT_LOCK.lock();
+    unsafe { INIT_TCS = thread::rsgx_thread_self() };
+
     INIT.call_once(|| {
         enclave::set_enclave_id(id as sgx_enclave_id_t);
         let s = unsafe {

--- a/sgx_tstd/src/sync/spinlock.rs
+++ b/sgx_tstd/src/sync/spinlock.rs
@@ -100,7 +100,7 @@ unsafe impl Send for SgxSpinlock {}
 unsafe impl Sync for SgxSpinlock {}
 
 impl SgxSpinlock {
-    pub fn new() -> SgxSpinlock {
+    pub const fn new() -> SgxSpinlock {
         SgxSpinlock{inner: SgxThreadSpinlock::new()}
     }
 

--- a/sgx_urts/Cargo.toml
+++ b/sgx_urts/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["rlib"]
 
 [features]
 default = []
-global_init = []
-global_exit = []
+global_init = ["global_exit"]
+global_exit = ["global_init"]
 signal = []
 
 


### PR DESCRIPTION
If EDMM is not supported, the `uninit_global_object` is forced to be triggered in `t_global_exit_ecall`.