### PR TITLE
bug fix call sched_getaffinity result segment fault

### DIFF
--- a/edl/sgx_sys.edl
+++ b/edl/sgx_sys.edl
@@ -26,7 +26,7 @@ enclave {
     untrusted {
         long u_sysconf_ocall([out] int *error, int name);
         int u_prctl_ocall([out] int *error, int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5);
-        int u_sched_setaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [in]cpu_set_t *mask);
-        int u_sched_getaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [out]cpu_set_t *mask);
+        int u_sched_setaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [in, size=cpusetsize]cpu_set_t *mask);
+        int u_sched_getaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [out, size=cpusetsize]cpu_set_t *mask);
     };
 };

--- a/sgx_edl/edl/sgx_sys.edl
+++ b/sgx_edl/edl/sgx_sys.edl
@@ -26,7 +26,7 @@ enclave {
     untrusted {
         long u_sysconf_ocall([out] int *error, int name);
         int u_prctl_ocall([out] int *error, int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5);
-        int u_sched_setaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [in]cpu_set_t *mask);
-        int u_sched_getaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [out]cpu_set_t *mask);
+        int u_sched_setaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [in, size=cpusetsize]cpu_set_t *mask);
+        int u_sched_getaffinity_ocall([out] int *error, pid_t pid, size_t cpusetsize, [out, size=cpusetsize]cpu_set_t *mask);
     };
 };


### PR DESCRIPTION
test code
 

    from "sgx_sys.edl" import *;

    sgx_libc = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
    sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
    
    use sgx_libc::ocall::sched_getaffinity;
    use sgx_libc::cpu_set_t;
    const MAX_CPUS: usize = 64 * 1024;
    let mut buf = [0; MAX_CPUS / 8];
    unsafe {
        sched_getaffinity(0, buf.len(), &mut buf as *mut _ as *mut cpu_set_t)
    };
`
Crash stack
`
(gdb) bt
#0  __memset_avx2_erms () at ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:145
#1  0x00007ffff7ae5ff7 in __GI___sched_getaffinity_new (pid=<optimized out>, cpusetsize=<optimized out>, cpuset=<optimized out>) at ../sysdeps/unix/sysv/linux/sched_getaffinity.c:41
#2  0x00005555555582c6 in u_sched_getaffinity_ocall ()
#3  0x0000555555556528 in Enclave_u_sched_getaffinity_ocall ()
#4  0x00007ffff7fb85cf in CEnclave::ocall(unsigned int, _ocall_table_t const*, void*) () from /usr/lib/x86_64-linux-gnu/libsgx_urts.so
#5  0x00007ffff7fb5916 in stack_sticker () from /usr/lib/x86_64-linux-gnu/libsgx_urts.so
#6  0x00007ffff6821acb in __morestack ()
#7  0x00007ffff6821acb in __morestack ()
#8  0x00007ffff6808dcd in u_sched_getaffinity_ocall ()
#9  0x00007ffff681582d in sgx_libc::linux::x86_64::ocall::sched_getaffinity ()
#10 0x00007ffff680ffde in say_something ()
#11 0x00007ffff680316f in sgx_say_something ()
#12 0x00007ffff680a643 in do_ecall ()
#13 0x00007ffff6821725 in enter_enclave ()
#14 0x00007ffff682193f in enclave_entry ()
#15 0x00007ffff7fb5845 in __morestack () from /usr/lib/x86_64-linux-gnu/libsgx_urts.so
#16 0x0000000000000000 in ?? ()
