### PR TITLE
feat(sgx_types): add traits using derive

### DIFF
--- a/sgx_types/Cargo.toml
+++ b/sgx_types/Cargo.toml
@@ -13,5 +13,6 @@ name = "sgx_types"
 
 [features]
 default = []
+extra_traits = []
 
 [dependencies]

--- a/sgx_types/src/macros.rs
+++ b/sgx_types/src/macros.rs
@@ -89,6 +89,7 @@ macro_rules! __item {
 macro_rules! impl_copy_clone{
     ($($(#[$attr:meta])* pub struct $i:ident { $($field:tt)* })*) => ($(
         $crate::__item! {
+            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, PartialEq))]
             #[repr(C)]
             $(#[$attr])*
             pub struct $i { $($field)* }
@@ -119,6 +120,7 @@ macro_rules! s {
 macro_rules! impl_struct {
     ($($(#[$attr:meta])* pub struct $i:ident { $(pub $name:ident: $field:ty,)* })*) => ($(
         $crate::__item! {
+            #[cfg_attr(feature = "extra_traits", derive(Debug, Eq, PartialEq))]
             #[repr(C)]
             $(#[$attr])*
             pub struct $i { $(pub $name: $field,)* }
@@ -133,6 +135,44 @@ macro_rules! impl_struct {
             }
         }
         unsafe impl $crate::marker::ContiguousMemory for $i {}
+    )*)
+}
+
+macro_rules! impl_packed_struct {
+    ($($(#[$attr:meta])* pub struct $i:ident { $(pub $name:ident: $field:ty,)* })*) => ($(
+        $crate::__item! {
+            #[cfg_attr(feature = "extra_traits", derive(Copy, Debug, Eq, PartialEq))]
+            #[repr(C, packed)]
+            $(#[$attr])*
+            pub struct $i { $(pub $name: $field,)* }
+        }
+        #[cfg(not(feature = "extra_traits"))]
+        impl Copy for $i {}
+        impl Clone for $i {
+            fn clone(&self) -> $i { *self }
+        }
+        impl Default for $i {
+            fn default()->$i {
+                $i{$($name: Default::default(),)*}
+            }
+        }
+        unsafe impl $crate::marker::ContiguousMemory for $i {}
+    )*)
+}
+
+macro_rules! impl_packed_copy_clone {
+    ($($(#[$attr:meta])* pub struct $i:ident { $($field:tt)* })*) => ($(
+        $crate::__item! {
+            #[cfg_attr(feature = "extra_traits", derive(Copy, Debug, Eq, PartialEq))]
+            #[repr(C, packed)]
+            $(#[$attr])*
+            pub struct $i { $($field)* }
+        }
+        #[cfg(not(feature = "extra_traits"))]
+        impl Copy for $i {}
+        impl Clone for $i {
+            fn clone(&self) -> $i { *self }
+        }
     )*)
 }
 

--- a/sgx_types/src/metadata.rs
+++ b/sgx_types/src/metadata.rs
@@ -112,8 +112,7 @@ pub const STATIC_STACK_SIZE: usize = 688;
 pub const SE_GUARD_PAGE_SHIFT: usize = 16;
 pub const SE_GUARD_PAGE_SIZE: usize = 1 << SE_GUARD_PAGE_SHIFT;
 
-impl_struct! {
-    #[repr(C, packed)]
+impl_packed_struct! {
     pub struct data_directory_t {
         pub offset :u32,
         pub size :u32,
@@ -122,7 +121,7 @@ impl_struct! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum dir_index_t {
         DIR_PATCH  = 0,
         DIR_LAYOUT = 1,
@@ -156,8 +155,7 @@ pub const LAYOUT_ID_RSRV_MAX: u32 = 22;
 
 type si_flags_t = u64;
 
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct layout_entry_t {
         pub id :u16,
         pub attributes :u16,
@@ -168,7 +166,6 @@ impl_struct! {
         pub si_flags :si_flags_t,
     }
 
-    #[repr(packed)]
     pub struct layout_group_t {
         pub id :u16,
         pub entry_count :u16,

--- a/sgx_types/src/types.rs
+++ b/sgx_types/src/types.rs
@@ -81,34 +81,29 @@ pub const TSEAL_DEFAULT_MISCMASK: uint32_t     = !MISC_NON_SECURITY_BITS;
 pub const SGX_DH_MAC_SIZE: size_t           = 16;
 pub const SGX_DH_SESSION_DATA_SIZE: size_t  = 200;
 
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_dh_msg1_t {
         pub g_a: sgx_ec256_public_t,
         pub target: sgx_target_info_t,
     }
 
-    #[repr(packed)]
     pub struct sgx_dh_msg2_t {
         pub g_b: sgx_ec256_public_t,
         pub report: sgx_report_t,
         pub cmac: [uint8_t; SGX_DH_MAC_SIZE],
     }
 
-    #[repr(packed)]
     pub struct sgx_dh_msg3_body_t {
         pub report: sgx_report_t,
         pub additional_prop_length: uint32_t,
         pub additional_prop: [uint8_t; 0],
     }
 
-    #[repr(packed)]
     pub struct sgx_dh_msg3_t {
         pub cmac: [uint8_t; SGX_DH_MAC_SIZE],
         pub msg3_body: sgx_dh_msg3_body_t,
     }
 
-    #[repr(packed)]
     pub struct sgx_dh_session_enclave_identity_t {
         pub cpu_svn: sgx_cpu_svn_t,
         pub misc_select: sgx_misc_select_t,
@@ -122,7 +117,6 @@ impl_copy_clone! {
         pub isv_svn: sgx_isv_svn_t,
     }
 
-    #[repr(packed)]
     pub struct sgx_dh_session_t {
         pub sgx_dh_session: [uint8_t; SGX_DH_SESSION_DATA_SIZE],
     }
@@ -148,7 +142,7 @@ impl_struct_ContiguousMemory! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_dh_session_role_t {
         SGX_DH_SESSION_INITIATOR = 0,
         SGX_DH_SESSION_RESPONDER = 1,
@@ -160,8 +154,7 @@ impl_enum! {
 //
 pub const SGX_FEBITSIZE: uint32_t = 256;
 
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct sgx_ecc_param_t {
         pub eccP: [uint32_t; SGX_NISTP_ECP256_KEY_SIZE],      /* EC prime field */
         pub eccA: [uint32_t; SGX_NISTP_ECP256_KEY_SIZE],      /* EC curve coefficient A */
@@ -247,7 +240,7 @@ pub type sgx_ra_key_128_t = sgx_key_128bit_t;
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_ra_key_type_t {
         SGX_RA_KEY_SK = 1,
         SGX_RA_KEY_MK = 2,
@@ -302,23 +295,19 @@ impl_struct_ContiguousMemory! {
 pub type sgx_epid_group_id_t = [uint8_t; 4];
 pub const SGX_PLATFORM_INFO_SIZE: size_t = 101;
 
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct sgx_spid_t {
         pub id: [uint8_t; 16],
     }
 
-    #[repr(packed)]
     pub struct sgx_basename_t {
         pub name: [uint8_t; 32],
     }
 
-    #[repr(packed)]
     pub struct sgx_quote_nonce_t {
         pub rand: [uint8_t; 16],
     }
 
-    #[repr(packed)]
     pub struct sgx_update_info_bit_t {
         pub ucodeUpdate: int32_t,
         pub csmeFwUpdate: int32_t,
@@ -328,15 +317,14 @@ impl_struct! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_quote_sign_type_t {
         SGX_UNLINKABLE_SIGNATURE    = 0,
         SGX_LINKABLE_SIGNATURE      = 1,
     }
 }
 
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_quote_t {
         pub version: uint16_t,                    /* 0   */
         pub sign_type: uint16_t,                  /* 2   */
@@ -350,13 +338,11 @@ impl_copy_clone! {
         pub signature: [uint8_t; 0],              /* 436 */
     }
 
-    #[repr(packed)]
     pub struct sgx_platform_info_t {
         pub platform_info: [uint8_t; SGX_PLATFORM_INFO_SIZE],
     }
 
     /* intel sgx sdk 2.5 */
-    #[repr(packed)]
     pub struct sgx_att_key_id_t {
         pub att_key_id: [uint8_t; 256],
     }
@@ -364,7 +350,6 @@ impl_copy_clone! {
     /* intel sgx sdk 2.9.1 */
     /* sgx_ql_att_key_id_t moved from sgx_quote_3.h to sgx_quote.h */
     /* Describes a single attestation key. Contains both QE identity and the attestation algorithm ID. */
-    #[repr(packed)]
     pub struct sgx_ql_att_key_id_t {
         pub id: uint16_t,                       //< Structure ID
         pub version: uint16_t,                  //< Structure version
@@ -381,7 +366,6 @@ impl_copy_clone! {
     /* intel sgx sdk 2.9.1 */
     /* sgx_att_key_id_ext_t moved from sgx_quote_3.h to sgx_quote.h */
     /* Describes an extended attestation key. Contains sgx_ql_att_key_id_t, spid and quote_type */
-    #[repr(packed)]
     pub struct sgx_att_key_id_ext_t {
         pub base: sgx_ql_att_key_id_t,
         pub spid: [uint8_t; 16],                //< Service Provider ID, should be 0s for ECDSA quote
@@ -390,7 +374,6 @@ impl_copy_clone! {
         pub reserved: [uint8_t; 80],            //< It should have the same size of sgx_att_key_id_t
     }
 
-    #[repr(packed)]
     pub struct sgx_qe_report_info_t {
         pub nonce: sgx_quote_nonce_t,
         pub app_enclave_target_info: sgx_target_info_t,
@@ -673,7 +656,7 @@ pub type sgx_aes_ctr_128bit_key_t = [uint8_t; SGX_AESCTR_KEY_SIZE];
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_generic_ecresult_t {
         SGX_EC_VALID                = 0x0000_0000,   /* validation pass successfully */
         SGX_EC_COMPOSITE_BASE       = 0x0000_0001,   /* field based on composite */
@@ -698,7 +681,7 @@ impl_enum! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_rsa_result_t {
         SGX_RSA_VALID               = 0,   /* validation pass successfully */
         SGX_RSA_INVALID_SIGNATURE   = 1,   /* invalid signature */
@@ -708,7 +691,7 @@ impl_enum! {
 /* intel sgx sdk 2.1.3 */
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_rsa_key_type_t {
         SGX_RSA_PRIVATE_KEY     = 0,   /* RSA private key state */
         SGX_RSA_PUBLIC_KEY      = 1,   /* RSA public key state */
@@ -890,7 +873,7 @@ pub const EXCEPTION_CONTINUE_EXECUTION: int32_t = -1;
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_exception_vector_t {
         SGX_EXCEPTION_VECTOR_DE = 0,  /* DIV and DIV instructions */
         SGX_EXCEPTION_VECTOR_DB = 1,  /* For Intel use only */
@@ -908,7 +891,7 @@ impl_enum! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_exception_type_t {
         SGX_EXCEPTION_HARDWARE = 3,
         SGX_EXCEPTION_SOFTWARE = 6,
@@ -1053,8 +1036,7 @@ pub const _SGX_EX_FEATURES_MASK_: uint32_t =
     0xFFFF_FFFF_u32 >> (MAX_EX_FEATURES_COUNT as uint32_t - 1 - _SGX_LAST_EX_FEATURE_IDX_);
 
 /* intel sgx sdk 2.4 */
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_kss_config_t {
         pub config_id: sgx_config_id_t,
         pub config_svn: sgx_config_svn_t,
@@ -1107,7 +1089,7 @@ pub const FOPEN_MAX: c_uint = 20; //define in sgx_tprotected_fs.h
 //
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_device_status_t {
         SGX_ENABLED                     = 0,
         SGX_DISABLED_REBOOT_REQUIRED    = 1,  /* A reboot is required to finish enabling SGX */
@@ -1135,7 +1117,7 @@ pub const SGX_PCL_GUID: [uint8_t; SGX_PCL_GUID_SIZE] = [
 //
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_uswitchless_worker_type_t {
         SGX_USWITCHLESS_WORKER_TYPE_UNTRUSTED  = 0,
         SGX_USWITCHLESS_WORKER_TYPE_TRUSTED    = 1,
@@ -1144,7 +1126,7 @@ impl_enum! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_uswitchless_worker_event_t {
         SGX_USWITCHLESS_WORKER_EVENT_START  = 0,  /* a worker thread starts */
         SGX_USWITCHLESS_WORKER_EVENT_IDLE   = 1,  /* a worker thread is idle */
@@ -1203,7 +1185,7 @@ pub const PCE_NIST_P256_ECDSA_SHA256: uint8_t = 0;
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_ql_request_policy_t {
         SGX_QL_PERSISTENT  = 0,  /* QE is initialized on first use and reused until process ends */
         SGX_QL_EPHEMERAL   = 1,  /* QE is initialized and terminated on every quote. If a previous QE exists, it is stopped & restarted before quoting.*/
@@ -1211,8 +1193,7 @@ impl_enum! {
     }
 }
 
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct sgx_pce_info_t {
         pub pce_isv_svn: sgx_isv_svn_t,
         pub pce_id: uint16_t,
@@ -1222,8 +1203,7 @@ impl_struct! {
 //
 // sgx_ql_lib_common.h
 //
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct sgx_ql_qe3_id_t {
         pub id: [uint8_t; 16],
     }
@@ -1231,7 +1211,7 @@ impl_struct! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_ql_config_version_t {
         SGX_QL_CONFIG_VERSION_1  = 1,
     }
@@ -1286,7 +1266,7 @@ pub const REF_QUOTE_MAX_AUTHENTICATON_DATA_SIZE: uint16_t = 64;
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_ql_attestation_algorithm_id_t {
         SGX_QL_ALG_EPID         = 0,
         SGX_QL_ALG_RESERVED_1   = 1,
@@ -1298,7 +1278,7 @@ impl_enum! {
 
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_ql_cert_key_type_t {
         PPID_CLEARTEXT          = 1,
         PPID_RSA2048_ENCRYPTED  = 2,
@@ -1310,8 +1290,7 @@ impl_enum! {
     }
 }
 
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_ql_ppid_rsa3072_encrypted_cert_info_t {
         pub enc_ppid: [uint8_t; 384],
         pub cpu_svn: sgx_cpu_svn_t,
@@ -1327,14 +1306,12 @@ impl_struct_ContiguousMemory! {
     sgx_ql_ppid_rsa3072_encrypted_cert_info_t;
 }
 
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct sgx_ql_auth_data_t {
         pub size: uint16_t,
         pub auth_data: [uint8_t; 0],
     }
 
-    #[repr(packed)]
     pub struct sgx_ql_certification_data_t {
         pub cert_key_type: uint16_t,
         pub size: uint32_t,
@@ -1342,8 +1319,7 @@ impl_struct! {
     }
 }
 
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_ql_ecdsa_sig_data_t {
         pub sig: [uint8_t; 64],
         pub attest_pub_key: [uint8_t; 64],
@@ -1361,8 +1337,7 @@ impl_struct_ContiguousMemory! {
     sgx_ql_ecdsa_sig_data_t;
 }
 
-impl_struct! {
-    #[repr(packed)]
+impl_packed_struct! {
     pub struct sgx_quote_header_t {
         pub version: uint16_t,
         pub att_key_type: uint16_t,
@@ -1374,8 +1349,7 @@ impl_struct! {
     }
 }
 
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_quote3_t {
         pub header: sgx_quote_header_t,
         pub report_body: sgx_report_body_t,
@@ -1395,8 +1369,7 @@ impl_struct_ContiguousMemory! {
 //
 // sgx_ql_quote.h
 //
-impl_copy_clone! {
-    #[repr(packed)]
+impl_packed_copy_clone! {
     pub struct sgx_ql_qe_report_info_t {
         pub nonce: sgx_quote_nonce_t,
         pub app_enclave_target_info: sgx_target_info_t,
@@ -1418,7 +1391,7 @@ impl_struct_ContiguousMemory! {
 //
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_ql_path_type_t {
         SGX_QL_QE3_PATH = 0,
         SGX_QL_PCE_PATH = 1,
@@ -1436,7 +1409,7 @@ pub const PLATFORM_INSTANCE_ID_SIZE: usize = 16;
 /* intel DCAP 1.7 */
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum pck_cert_flag_enum_t {
         PCK_FLAG_FALSE = 0,
         PCK_FLAG_TRUE = 1,
@@ -1483,7 +1456,7 @@ impl_struct_ContiguousMemory! {
 //
 impl_enum! {
     #[repr(u32)]
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum sgx_qv_path_type_t {
         SGX_QV_QVE_PATH  = 0,
         SGX_QV_QPL_PATH  = 1,
@@ -1512,11 +1485,51 @@ pub struct sgx_align_key_128bit_t {
     pub key: sgx_key_128bit_t,
 }
 
+#[cfg(feature = "extra_traits")]
+impl PartialEq for sgx_align_key_128bit_t {
+    #[inline]
+    fn eq(&self, other: &sgx_align_key_128bit_t) -> bool {
+        self.key.eq(&other.key)
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl Eq for sgx_align_key_128bit_t {}
+
+#[cfg(feature = "extra_traits")]
+impl core::fmt::Debug for sgx_align_key_128bit_t {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("sgx_align_key_128bit_t")
+            .field("key", &self.key)
+            .finish()
+    }
+}
+
 #[repr(C, align(32))]
 #[derive(Copy, Clone, Default)]
 pub struct sgx_align_mac_128bit_t {
     _pad: [uint8_t; 16],
     pub mac: sgx_mac_128bit_t,
+}
+
+#[cfg(feature = "extra_traits")]
+impl PartialEq for sgx_align_mac_128bit_t {
+    #[inline]
+    fn eq(&self, other: &sgx_align_mac_128bit_t) -> bool {
+        self.mac.eq(&other.mac)
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl Eq for sgx_align_mac_128bit_t {}
+
+#[cfg(feature = "extra_traits")]
+impl core::fmt::Debug for sgx_align_mac_128bit_t {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("sgx_align_mac_128bit_t")
+            .field("mac", &self.mac)
+            .finish()
+    }
 }
 
 #[repr(C, align(64))]
@@ -1526,11 +1539,52 @@ pub struct sgx_align_key_256bit_t {
     pub key: sgx_key_256bit_t,
 }
 
+#[cfg(feature = "extra_traits")]
+impl PartialEq for sgx_align_key_256bit_t {
+    #[inline]
+    fn eq(&self, other: &sgx_align_key_256bit_t) -> bool {
+        self.key.eq(&other.key)
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl Eq for sgx_align_key_256bit_t {}
+
+#[cfg(feature = "extra_traits")]
+impl core::fmt::Debug for sgx_align_key_256bit_t {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("sgx_align_key_256bit_t")
+            .field("key", &self.key)
+            .finish()
+    }
+}
+
+
 #[repr(C, align(64))]
 #[derive(Copy, Clone, Default)]
 pub struct sgx_align_mac_256bit_t {
     _pad: [uint8_t; 8],
     pub mac: sgx_mac_256bit_t,
+}
+
+#[cfg(feature = "extra_traits")]
+impl PartialEq for sgx_align_mac_256bit_t {
+    #[inline]
+    fn eq(&self, other: &sgx_align_mac_256bit_t) -> bool {
+        self.mac.eq(&other.mac)
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl Eq for sgx_align_mac_256bit_t {}
+
+#[cfg(feature = "extra_traits")]
+impl core::fmt::Debug for sgx_align_mac_256bit_t {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("sgx_align_mac_256bit_t")
+            .field("mac", &self.mac)
+            .finish()
+    }
 }
 
 #[repr(C, align(64))]
@@ -1540,11 +1594,51 @@ pub struct sgx_align_ec256_dh_shared_t {
     pub key: sgx_ec256_dh_shared_t,
 }
 
+#[cfg(feature = "extra_traits")]
+impl PartialEq for sgx_align_ec256_dh_shared_t  {
+    #[inline]
+    fn eq(&self, other: &sgx_align_ec256_dh_shared_t) -> bool {
+        self.key.eq(&other.key)
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl Eq for sgx_align_ec256_dh_shared_t {}
+
+#[cfg(feature = "extra_traits")]
+impl core::fmt::Debug for sgx_align_ec256_dh_shared_t {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("sgx_align_ec256_dh_shared_t")
+            .field("key", &self.key)
+            .finish()
+    }
+}
+
 #[repr(C, align(64))]
 #[derive(Copy, Clone, Default)]
 pub struct sgx_align_ec256_private_t {
     _pad: [uint8_t; 8],
     pub key: sgx_ec256_private_t,
+}
+
+#[cfg(feature = "extra_traits")]
+impl PartialEq for sgx_align_ec256_private_t  {
+    #[inline]
+    fn eq(&self, other: &sgx_align_ec256_private_t) -> bool {
+        self.key.eq(&other.key)
+    }
+}
+
+#[cfg(feature = "extra_traits")]
+impl Eq for sgx_align_ec256_private_t {}
+
+#[cfg(feature = "extra_traits")]
+impl core::fmt::Debug for sgx_align_ec256_private_t {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("sgx_align_ec256_private_t")
+            .field("key", &self.key)
+            .finish()
+    }
 }
 
 unsafe impl ContiguousMemory for sgx_align_key_128bit_t {}


### PR DESCRIPTION
I started implementing the Debug and PartialEq traits using derive. This is to facilitate creating strategies with [proptest](https://github.com/AltSysrq/proptest) and to allow us to easily compare results after the test.

This is WIP, but I wanted to open it up for feedback and to get an idea on if this makes sense to add.