### PR TITLE
Fix link to http_req-sgx

### DIFF
--- a/samplecode/http_req/README.md
+++ b/samplecode/http_req/README.md
@@ -1,6 +1,6 @@
 # http_req-sgx-example
 
-Showcases [http_req-sgx](https://github.com/piotr-roslaniec/http_req-sgx-example) inside an SGX enclave.
+Showcases [http_req-sgx](https://github.com/mesalock-linux/http_req-sgx) inside an SGX enclave.
 
 ## Instruction
 


### PR DESCRIPTION
Replaces a dead link with the project that is referenced in `Cargo.toml`.