### PR TITLE
Fix samplecode compiler error with newer GCC.

### DIFF
--- a/sgx_unwind/libunwind/include/libunwind_i.h
+++ b/sgx_unwind/libunwind/include/libunwind_i.h
@@ -272,7 +272,6 @@ extern void unwi_dyn_remote_put_unwind_info (unw_addr_space_t as,
         void *arg);
 extern int unwi_dyn_validate_cache (unw_addr_space_t as, void *arg);
 
-extern unw_dyn_info_list_t _U_dyn_info_list;
 extern pthread_mutex_t _U_dyn_info_list_lock;
 
 #if UNW_DEBUG && !HAVE_SGX

--- a/sgx_unwind/libunwind/src/x86_64/Ginit.c
+++ b/sgx_unwind/libunwind/src/x86_64/Ginit.c
@@ -47,13 +47,6 @@ static struct unw_addr_space local_addr_space;
 
 PROTECTED unw_addr_space_t unw_local_addr_space = &local_addr_space;
 
-HIDDEN unw_dyn_info_list_t _U_dyn_info_list;
-
-/* XXX fix me: there is currently no way to locate the dyn-info list
-       by a remote unwinder.  On ia64, this is done via a special
-       unwind-table entry.  Perhaps something similar can be done with
-       DWARF2 unwind info.  */
-
 static void
 put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
 {
@@ -64,7 +57,13 @@ static int
 get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
                         void *arg)
 {
-    *dyn_info_list_addr = (unw_word_t) &_U_dyn_info_list;
+#ifndef UNW_LOCAL_ONLY
+# pragma weak _U_dyn_info_list_addr
+    if (!_U_dyn_info_list_addr)
+        return -UNW_ENOINFO;
+#endif
+    // Access the `_U_dyn_info_list` from `LOCAL_ONLY` library, i.e. libunwind.so.
+    *dyn_info_list_addr = _U_dyn_info_list_addr ();
     return 0;
 }
 


### PR DESCRIPTION
Fix #313.

Introduce changes from upstream to fix multiple definition of '_U_dyn_info_list'. 
Tested on Debian bullseye/sid and Ubuntu 18.04.

Upstream link: https://github.com/libunwind/libunwind/commit/29e17d.