### PR TITLE
remove not-in-use fixed_size_array feature

### DIFF
--- a/sgx_tstd/src/lib.rs
+++ b/sgx_tstd/src/lib.rs
@@ -63,7 +63,6 @@
 #![feature(custom_test_frameworks)]
 #![feature(dropck_eyepatch)]
 #![feature(extend_one)]
-#![feature(fixed_size_array)]
 #![feature(fn_traits)]
 #![feature(generator_trait)]
 #![feature(format_args_nl)]


### PR DESCRIPTION
It seems `fixed_size_array` feature (I search `FixedSizeArray` in the repo and not found anything) are not in use, and it has been removed in latest `rustc` (see: https://github.com/rust-lang/rust/pull/84094)