### PR TITLE
Import asm macro

### DIFF
--- a/sgx_trts/src/trts.rs
+++ b/sgx_trts/src/trts.rs
@@ -16,6 +16,7 @@
 // under the License..
 
 use crate::libc;
+use core::arch::asm;
 use core::mem;
 use sgx_types::marker::ContiguousMemory;
 use sgx_types::*;

--- a/sgx_tstd/src/prelude/v1.rs
+++ b/sgx_tstd/src/prelude/v1.rs
@@ -51,12 +51,6 @@ pub use core::prelude::v1::{
     PartialOrd,
 };
 
-#[doc(no_inline)]
-pub use core::prelude::v1::asm;
-
-#[doc(no_inline)]
-pub use core::prelude::v1::global_asm;
-
 // FIXME: Attribute and internal derive macros are not documented because for them rustdoc generates
 // dead links which fail link checker testing.
 #[allow(deprecated, deprecated_in_future)]


### PR DESCRIPTION
The macro got removed from the prelude on stabilization (stabilized in 1.59).