### PR TITLE
feat: new feature gate `initenv` to disable env ocalls on demand

### DIFF
--- a/rustlib/std/Cargo.toml
+++ b/rustlib/std/Cargo.toml
@@ -34,6 +34,7 @@ crate-type = ["rlib"]
 default = ["stdio", "panic_unwind"]
 backtrace = ["stdio", "sgx_backtrace_sys", "sgx_demangle"]
 stdio = []
+env = ["sgx_oc/init_env"]
 net = []
 pipe = []
 thread = ["sgx_trts/thread"]
@@ -48,7 +49,7 @@ sgx_alloc = { path = "../../sgx_alloc" }
 sgx_backtrace_sys = { path = "../../sgx_backtrace/sgx_backtrace_sys", optional = true }
 sgx_demangle = { path = "../../sgx_demangle", optional = true }
 sgx_ffi = { path = "../../sgx_ffi" }
-sgx_oc = { path = "../../sgx_oc" }
+sgx_oc = { path = "../../sgx_oc", default-features = false, features = ["align"] }
 sgx_sync = { path = "../../sgx_sync" }
 sgx_trts = { path = "../../sgx_trts" }
 sgx_types = { path = "../../sgx_types" }

--- a/samplecode/rpc/client/enclave/enclave.edl
+++ b/samplecode/rpc/client/enclave/enclave.edl
@@ -20,7 +20,7 @@ enclave {
     from "sgx_net.edl" import *;
     from "sgx_fs.edl" import *;
     from "sgx_thread.edl" import *;
-    from "sgx_cpuid.edl" import *;
+    from "sgx_process.edl" import *;
     from "sgx_tstd.edl" import *;
 
     trusted {

--- a/samplecode/rpc/server/enclave/enclave.edl
+++ b/samplecode/rpc/server/enclave/enclave.edl
@@ -20,7 +20,7 @@ enclave {
     from "sgx_net.edl" import *;
     from "sgx_fs.edl" import *;
     from "sgx_thread.edl" import *;
-    from "sgx_cpuid.edl" import *;
+    from "sgx_process.edl" import *;
     from "sgx_tstd.edl" import *;
 
     trusted {

--- a/sgx_edl/edl/sgx_tstd.edl
+++ b/sgx_edl/edl/sgx_tstd.edl
@@ -16,8 +16,6 @@
 // under the License.
 
 enclave {
-    from "sgx_env.edl" import *;
     from "sgx_sync.edl" import *;
     from "sgx_time.edl" import *;
-    from "sgx_process.edl" import *;
 };

--- a/sgx_oc/Cargo.toml
+++ b/sgx_oc/Cargo.toml
@@ -30,9 +30,10 @@ name = "sgx_oc"
 crate-type = ["rlib"]
 
 [features]
-default = ["align"]
+default = ["align", "init_env"]
 align = []
 extra_traits = []
+init_env = []
 
 [dependencies]
 sgx_sync = { path = "../sgx_sync" }

--- a/sgx_tstd/Cargo.toml
+++ b/sgx_tstd/Cargo.toml
@@ -30,11 +30,12 @@ name = "sgx_tstd"
 crate-type = ["rlib"]
 
 [features]
-default = ["stdio"]
+default = ["stdio", "initenv"]
 backtrace = ["stdio", "sgx_backtrace_sys", "sgx_demangle"]
 stdio = []
 net = []
 pipe = []
+initenv = []
 thread = ["sgx_trts/thread"]
 untrusted_fs = []
 untrusted_time = []

--- a/sgx_tstd/Cargo.toml
+++ b/sgx_tstd/Cargo.toml
@@ -30,24 +30,24 @@ name = "sgx_tstd"
 crate-type = ["rlib"]
 
 [features]
-default = ["stdio", "initenv"]
+default = ["stdio"]
 backtrace = ["stdio", "sgx_backtrace_sys", "sgx_demangle"]
 stdio = []
+env = ["sgx_oc/init_env"]
 net = []
 pipe = []
-initenv = []
 thread = ["sgx_trts/thread"]
 untrusted_fs = []
 untrusted_time = []
 unsupported_process = []
-unit_test = ["sgx_test_utils", "backtrace", "thread", "net", "pipe", "untrusted_fs", "untrusted_time", "unsupported_process"]
+unit_test = ["sgx_test_utils", "backtrace", "env", "thread", "net", "pipe", "untrusted_fs", "untrusted_time", "unsupported_process"]
 
 [dependencies]
 sgx_alloc = { path = "../sgx_alloc" }
 sgx_backtrace_sys = { path = "../sgx_backtrace/sgx_backtrace_sys", optional = true }
 sgx_demangle = { path = "../sgx_demangle", optional = true }
 sgx_ffi = { path = "../sgx_ffi" }
-sgx_oc = { path = "../sgx_oc" }
+sgx_oc = { path = "../sgx_oc", default-features = false, features = ["align"] }
 sgx_sync = { path = "../sgx_sync" }
 sgx_trts = { path = "../sgx_trts" }
 sgx_types = { path = "../sgx_types" }

--- a/sgx_tstd/src/enclave.rs
+++ b/sgx_tstd/src/enclave.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License..
 
+use crate::fs;
 use crate::io;
 use crate::path::{Path, PathBuf};
-use crate::untrusted::fs;
 
 use sgx_sync::SpinMutex;
 use sgx_types::types::EnclaveId;

--- a/sgx_tstd/src/env.rs
+++ b/sgx_tstd/src/env.rs
@@ -33,8 +33,11 @@ mod tests;
 use crate::error::Error;
 use crate::ffi::{OsStr, OsString};
 use crate::fmt;
+#[cfg(feature = "env")]
 use crate::io;
-use crate::path::{Path, PathBuf};
+#[cfg(feature = "env")]
+use crate::path::Path;
+use crate::path::PathBuf;
 use crate::sys;
 use crate::sys::os as os_imp;
 
@@ -64,6 +67,7 @@ use crate::sys::os as os_imp;
 ///     Ok(())
 /// }
 /// ```
+#[cfg(feature = "env")]
 pub fn current_dir() -> io::Result<PathBuf> {
     os_imp::getcwd()
 }
@@ -87,6 +91,7 @@ pub fn current_dir() -> io::Result<PathBuf> {
 /// assert!(env::set_current_dir(&root).is_ok());
 /// println!("Successfully changed working directory to {}!", root.display());
 /// ```
+#[cfg(feature = "env")]
 pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     os_imp::chdir(path.as_ref())
 }
@@ -670,6 +675,7 @@ pub fn temp_dir() -> PathBuf {
 ///     Err(e) => println!("failed to get current exe path: {}", e),
 /// };
 /// ```
+#[cfg(feature = "env")]
 pub fn current_exe() -> io::Result<PathBuf> {
     os_imp::current_exe()
 }

--- a/sgx_tstd/src/os/fd/owned.rs
+++ b/sgx_tstd/src/os/fd/owned.rs
@@ -21,11 +21,11 @@
 
 use super::raw::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::fmt;
+use crate::fs;
 use crate::marker::PhantomData;
 use crate::mem::forget;
 use crate::sys::cvt_ocall;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
-use crate::untrusted::fs;
 
 /// A borrowed file descriptor.
 ///

--- a/sgx_tstd/src/os/fd/raw.rs
+++ b/sgx_tstd/src/os/fd/raw.rs
@@ -17,12 +17,12 @@
 
 //! Raw Unix-like file descriptors.
 
+use crate::fs;
 #[cfg(feature = "stdio")]
 use crate::io;
 use crate::os::raw;
 use crate::os::unix::io::OwnedFd;
 use crate::sys_common::{AsInner, IntoInner};
-use crate::untrusted::fs;
 
 #[cfg(feature = "stdio")]
 use sgx_oc as libc;

--- a/sgx_tstd/src/os/linux/fs.rs
+++ b/sgx_tstd/src/os/linux/fs.rs
@@ -19,8 +19,8 @@
 //!
 //! [`std::fs`]: crate::fs
 
+use crate::fs::Metadata;
 use crate::sys_common::AsInner;
-use crate::untrusted::fs::Metadata;
 
 #[allow(deprecated)]
 use crate::os::linux::raw;

--- a/sgx_tstd/src/os/unix/fs.rs
+++ b/sgx_tstd/src/os/unix/fs.rs
@@ -20,12 +20,12 @@
 //! [`std::fs`]: crate::fs
 
 use super::platform::fs::MetadataExt as _;
+use crate::fs::{self, OpenOptions, Permissions};
 use crate::io;
 use crate::os::unix::io::{AsFd, AsRawFd};
 use crate::path::Path;
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
-use crate::untrusted::fs::{self, OpenOptions, Permissions};
 // Used for `File::read` on intra-doc links
 use crate::ffi::OsStr;
 use crate::sealed::Sealed;

--- a/sgx_tstd/src/rt.rs
+++ b/sgx_tstd/src/rt.rs
@@ -25,6 +25,7 @@ pub use crate::sys_common::at_exit;
 pub use core::panicking::{panic_display, panic_fmt};
 
 use crate::enclave::Enclave;
+#[cfg(feature = "initenv")]
 use crate::ffi::CString;
 use crate::slice;
 use crate::str;
@@ -145,6 +146,7 @@ static INIT: Once = Once::new();
 static EXIT: Once = Once::new();
 
 #[no_mangle]
+#[allow(unused)]
 unsafe extern "C" fn global_init_ecall(
     eid: u64,
     path: *const u8,
@@ -164,26 +166,29 @@ unsafe extern "C" fn global_init_ecall(
             }
         }
 
-        let parse_vec = |ptr: *const u8, len: usize| -> Vec<CString> {
-            if !ptr.is_null() && len > 0 {
-                let buf = slice::from_raw_parts(ptr, len);
-                buf.split(|&c| c == 0)
-                    .filter_map(|bytes| {
-                        if !bytes.is_empty() {
-                            CString::new(bytes).ok()
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            }
-        };
+        #[cfg(feature = "initenv")]
+        {
+            let parse_vec = |ptr: *const u8, len: usize| -> Vec<CString> {
+                if !ptr.is_null() && len > 0 {
+                    let buf = slice::from_raw_parts(ptr, len);
+                    buf.split(|&c| c == 0)
+                        .filter_map(|bytes| {
+                            if !bytes.is_empty() {
+                                CString::new(bytes).ok()
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                }
+            };
 
-        let env = parse_vec(env, env_len);
-        let args = parse_vec(args, args_len);
-        sys::init(env, args);
+            let env = parse_vec(env, env_len);
+            let args = parse_vec(args, args_len);
+            sys::init(env, args);
+        }
     });
 }
 

--- a/sgx_tstd/src/sys/kernel_copy.rs
+++ b/sgx_tstd/src/sys/kernel_copy.rs
@@ -63,6 +63,7 @@
 
 use crate::cmp::min;
 use crate::convert::TryInto;
+use crate::fs::{File, Metadata};
 use crate::io::copy::generic_copy;
 use crate::io::{BufRead, BufReader, BufWriter, Error, Read, Result, Take, Write};
 #[cfg(feature = "stdio")]
@@ -76,7 +77,6 @@ use crate::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use crate::os::unix::net::UnixStream;
 use crate::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use crate::sys::cvt_ocall;
-use crate::untrusted::fs::{File, Metadata};
 use sgx_oc::{EBADF, EINVAL, ENOSYS, EOPNOTSUPP, EOVERFLOW, EPERM, EXDEV};
 
 #[cfg(feature = "unit_test")]

--- a/sgx_tstd/src/sys/mod.rs
+++ b/sgx_tstd/src/sys/mod.rs
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License..
 
+#[cfg(feature = "initenv")]
 use crate::ffi::CString;
 use crate::io::ErrorKind;
 
-use sgx_oc::ocall::{self, OCallResult};
+#[cfg(feature = "initenv")]
+use sgx_oc::ocall;
+use sgx_oc::ocall::OCallResult;
 use sgx_oc as libc;
 use sgx_trts::error::abort;
 
@@ -59,6 +62,7 @@ pub mod unsupported;
 
 // SAFETY: must be called only once during runtime initialization.
 // NOTE: this is not guaranteed to run, for example when Rust code is called externally.
+#[cfg(feature = "initenv")]
 pub unsafe fn init(env: Vec<CString>, args: Vec<CString>) {
     let _ = ocall::initenv(Some(env));
     let _ = ocall::initargs(Some(args));

--- a/sgx_tstd/src/sys/mod.rs
+++ b/sgx_tstd/src/sys/mod.rs
@@ -15,13 +15,10 @@
 // specific language governing permissions and limitations
 // under the License..
 
-#[cfg(feature = "initenv")]
 use crate::ffi::CString;
 use crate::io::ErrorKind;
 
-#[cfg(feature = "initenv")]
-use sgx_oc::ocall;
-use sgx_oc::ocall::OCallResult;
+use sgx_oc::ocall::{self, OCallResult};
 use sgx_oc as libc;
 use sgx_trts::error::abort;
 
@@ -62,7 +59,6 @@ pub mod unsupported;
 
 // SAFETY: must be called only once during runtime initialization.
 // NOTE: this is not guaranteed to run, for example when Rust code is called externally.
-#[cfg(feature = "initenv")]
 pub unsafe fn init(env: Vec<CString>, args: Vec<CString>) {
     let _ = ocall::initenv(Some(env));
     let _ = ocall::initargs(Some(args));

--- a/sgx_tstd/src/sys/path.rs
+++ b/sgx_tstd/src/sys/path.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use crate::env;
 use crate::ffi::OsStr;
 use crate::io;
 use crate::path::{Path, PathBuf, Prefix};
+use crate::sys::os;
 
 #[inline]
 pub fn is_sep_byte(b: u8) -> bool {
@@ -61,7 +61,7 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
             PathBuf::new()
         }
     } else {
-        env::current_dir()?
+        os::_getcwd()?
     };
     normalized.extend(components);
 

--- a/sgx_tstd/src/sys_common/fs.rs
+++ b/sgx_tstd/src/sys_common/fs.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use crate::untrusted::fs;
+use crate::fs;
 use crate::io::{self, Error, ErrorKind};
 use crate::path::Path;
 

--- a/sgx_tstd/src/untrusted/path.rs
+++ b/sgx_tstd/src/untrusted/path.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use crate::untrusted::fs;
+use crate::fs;
 use crate::io;
 use crate::path::{self, Path, PathBuf};
 

--- a/tests/enclave/enclave.edl
+++ b/tests/enclave/enclave.edl
@@ -25,6 +25,7 @@ enclave {
     from "sgx_cpuid.edl" import *;
     from "sgx_process.edl" import *;
     from "sgx_backtrace.edl" import *;
+    from "sgx_env.edl" import *;
     from "sgx_tstd.edl" import *;
     from "sgx_tprotected_fs.edl" import *;
 


### PR DESCRIPTION
we need a way to construct "0 ocall enclave" and this is the first move: make the env var access optional in sgx_tstd.

new feature gate proposed `initenv` which is by default open (backward compatible). disable this feature could statically remove `ocall::initenv` and `ocall::initargs`.