### PR TITLE
Add DCAP libraries

### DIFF
--- a/dockerfile/04_psw.sh
+++ b/dockerfile/04_psw.sh
@@ -22,7 +22,11 @@ curl -fsSL  https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key 
         libsgx-uae-service=$VERSION \
         libsgx-urts=$VERSION \
         sgx-aesm-service=$VERSION \
-	libsgx-ae-qe3=$DCAP_VERSION \
+        libsgx-ae-qe3=$DCAP_VERSION \
+        libsgx-dcap-ql=$DCAP_VERSION \
+        libsgx-dcap-ql-dev=$DCAP_VERSION \
+        libsgx-dcap-quote-verify=$DCAP_VERSION \
+        libsgx-dcap-quote-verify-dev=$DCAP_VERSION \
         libsgx-pce-logic=$DCAP_VERSION \
         libsgx-qe3-logic=$DCAP_VERSION \
         libsgx-ra-network=$DCAP_VERSION \


### PR DESCRIPTION
In order to compile a project with DCAP inside docker I had to add these libraries.
The `-dev` packages I had to add because they contain the symlinks from `*.so` to `*.so.1`. 