### PR TITLE
Install additional libraries into docker image

### DIFF
--- a/dockerfile/04_psw.sh
+++ b/dockerfile/04_psw.sh
@@ -27,6 +27,8 @@ curl -fsSL  https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key 
         libsgx-dcap-ql-dev=$DCAP_VERSION \
         libsgx-dcap-quote-verify=$DCAP_VERSION \
         libsgx-dcap-quote-verify-dev=$DCAP_VERSION \
+        libsgx-dcap-default-qpl=$DCAP_VERSION \
+        libsgx-dcap-default-qpl-dev=$DCAP_VERSION \
         libsgx-pce-logic=$DCAP_VERSION \
         libsgx-qe3-logic=$DCAP_VERSION \
         libsgx-ra-network=$DCAP_VERSION \


### PR DESCRIPTION
For the calling `sgx_ql_get_quote_verification_collateral(..)` I needed to install these additional libraries. 