### PR TITLE
Modify misuse regarding the use of ordering

### DIFF
--- a/samplecode/tls/tlsclient/enclave/src/lib.rs
+++ b/samplecode/tls/tlsclient/enclave/src/lib.rs
@@ -242,7 +242,7 @@ impl Sessions {
     fn new_session(svr_ptr : *mut TlsClient) -> Option<usize> {
         match GLOBAL_CONTEXTS.write() {
             Ok(mut gctxts) => {
-                let curr_id = GLOBAL_CONTEXT_COUNT.fetch_add(1, Ordering::SeqCst);
+                let curr_id = GLOBAL_CONTEXT_COUNT.fetch_add(1, Ordering::Relaxed);
                 gctxts.insert(curr_id, AtomicPtr::new(svr_ptr));
                 Some(curr_id)
             },

--- a/samplecode/tls/tlsserver/enclave/src/lib.rs
+++ b/samplecode/tls/tlsserver/enclave/src/lib.rs
@@ -178,7 +178,7 @@ impl Sessions {
     fn new_session(svr_ptr : *mut TlsServer) -> Option<usize> {
         match GLOBAL_CONTEXTS.write() {
             Ok(mut gctxts) => {
-                let curr_id = GLOBAL_CONTEXT_COUNT.fetch_add(1, Ordering::SeqCst);
+                let curr_id = GLOBAL_CONTEXT_COUNT.fetch_add(1, Ordering::Relaxed);
                 gctxts.insert(curr_id, AtomicPtr::new(svr_ptr));
                 Some(curr_id)
             },

--- a/sgx_tstd/hashbrown/benches/bench.rs
+++ b/sgx_tstd/hashbrown/benches/bench.rs
@@ -53,7 +53,7 @@ lazy_static::lazy_static! {
 struct DropType(usize);
 impl Drop for DropType {
     fn drop(&mut self) {
-        SIDE_EFFECT.fetch_add(self.0, atomic::Ordering::SeqCst);
+        SIDE_EFFECT.fetch_add(self.0, atomic::Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/495b91f6e690a8c7a3b94241ba58eb44cc22739d/sgx_tstd/hashbrown/benches/bench.rs#L56
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/495b91f6e690a8c7a3b94241ba58eb44cc22739d/samplecode/tls/tlsclient/enclave/src/lib.rs#L245
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/495b91f6e690a8c7a3b94241ba58eb44cc22739d/samplecode/tls/tlsserver/enclave/src/lib.rs#L181
I think the use of ordering here is irregular, AtomicUsize is used here for counting, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.