### PR TITLE
Modify misuse regarding the use of ordering

### DIFF
--- a/samplecode/localattestation/attestation/src/func.rs
+++ b/samplecode/localattestation/attestation/src/func.rs
@@ -48,15 +48,15 @@ extern {
 static CALLBACK_FN: AtomicPtr<()> = AtomicPtr::new(0 as * mut ());
 
 pub fn init(cb: Callback) {
-    let ptr = CALLBACK_FN.load(Ordering::SeqCst);
+    let ptr = CALLBACK_FN.load(Ordering::Relaxed);
     if ptr.is_null() {
         let ptr: * mut Callback = Box::into_raw(Box::new(cb));
-        CALLBACK_FN.store(ptr as * mut (), Ordering::SeqCst);
+        CALLBACK_FN.store(ptr as * mut (), Ordering::Relaxed);
     }
 }
 
 fn get_callback() -> Option<&'static Callback>{
-    let ptr = CALLBACK_FN.load(Ordering::SeqCst) as *mut Callback;
+    let ptr = CALLBACK_FN.load(Ordering::Relaxed) as *mut Callback;
     if ptr.is_null() {
          return None;
     }

--- a/samplecode/psi/SMCServer/enclave/src/lib.rs
+++ b/samplecode/psi/SMCServer/enclave/src/lib.rs
@@ -85,7 +85,7 @@ static GLOBAL_HASH_BUFFER: AtomicPtr<()> = AtomicPtr::new(0 as * mut ());
 
 fn get_ref_hash_buffer() -> Option<&'static RefCell<SetIntersection>>
 {
-    let ptr = GLOBAL_HASH_BUFFER.load(Ordering::SeqCst) as * mut RefCell<SetIntersection>;
+    let ptr = GLOBAL_HASH_BUFFER.load(Ordering::Relaxed) as * mut RefCell<SetIntersection>;
     if ptr.is_null() {
         None
     } else {
@@ -107,7 +107,7 @@ fn initialize() -> sgx_status_t {
 
     let data_box = Box::new(RefCell::<SetIntersection>::new(data));
     let ptr = Box::into_raw(data_box);
-    GLOBAL_HASH_BUFFER.store(ptr as *mut (), Ordering::SeqCst);
+    GLOBAL_HASH_BUFFER.store(ptr as *mut (), Ordering::Relaxed);
 
     sgx_status_t::SGX_SUCCESS
 }
@@ -116,7 +116,7 @@ fn initialize() -> sgx_status_t {
 pub extern "C"
 fn uninitialize() {
 
-    let ptr = GLOBAL_HASH_BUFFER.swap(0 as * mut (), Ordering::SeqCst) as * mut RefCell<SetIntersection>;
+    let ptr = GLOBAL_HASH_BUFFER.swap(0 as * mut (), Ordering::Relaxed) as * mut RefCell<SetIntersection>;
     if ptr.is_null() {
        return;
     }

--- a/samplecode/thread/enclave/src/lib.rs
+++ b/samplecode/thread/enclave/src/lib.rs
@@ -59,12 +59,12 @@ pub extern "C" fn ecall_initialize() {
         SgxCondvar::new(),
     ));
     let ptr = Box::into_raw(lock);
-    GLOBAL_COND_BUFFER.store(ptr as *mut (), Ordering::SeqCst);
+    GLOBAL_COND_BUFFER.store(ptr as *mut (), Ordering::Relaxed);
 }
 
 #[no_mangle]
 pub extern "C" fn ecall_uninitialize() {
-    let ptr = GLOBAL_COND_BUFFER.swap(0 as *mut (), Ordering::SeqCst)
+    let ptr = GLOBAL_COND_BUFFER.swap(0 as *mut (), Ordering::Relaxed)
         as *mut (SgxMutex<CondBuffer>, SgxCondvar, SgxCondvar);
     if ptr.is_null() {
         return;
@@ -73,7 +73,7 @@ pub extern "C" fn ecall_uninitialize() {
 }
 
 fn get_ref_cond_buffer() -> Option<&'static (SgxMutex<CondBuffer>, SgxCondvar, SgxCondvar)> {
-    let ptr = GLOBAL_COND_BUFFER.load(Ordering::SeqCst)
+    let ptr = GLOBAL_COND_BUFFER.load(Ordering::Relaxed)
         as *mut (SgxMutex<CondBuffer>, SgxCondvar, SgxCondvar);
     if ptr.is_null() {
         None


### PR DESCRIPTION
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/495b91f6e690a8c7a3b94241ba58eb44cc22739d/samplecode/localattestation/attestation/src/func.rs#L48
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/495b91f6e690a8c7a3b94241ba58eb44cc22739d/samplecode/psi/SMCServer/enclave/src/lib.rs#L84
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/495b91f6e690a8c7a3b94241ba58eb44cc22739d/samplecode/thread/enclave/src/lib.rs#L52
I think the use of ordering here is irregular. In teaclave, there will be no simultaneous read and write operations to CALLBACK_FN, GLOBAL_HASH_BUFFER and GLOBAL_COND_BUFFER in a multi-threaded environment, only simultaneous reads to them occur, so I think Ordering::Relaxed can be used here.