### PR TITLE
midified atomic::ordering about FIRST_PANIC

### DIFF
--- a/sgx_tstd/src/panicking.rs
+++ b/sgx_tstd/src/panicking.rs
@@ -285,7 +285,7 @@ fn default_hook(info: &PanicInfo<'_>) {
                     drop(backtrace::print(err, crate::sys::backtrace::PrintFmt::Full))
                 }
                 Some(BacktraceStyle::Off) => {
-                    if FIRST_PANIC.swap(false, Ordering::SeqCst) {
+                    if FIRST_PANIC.swap(false, Ordering::Relaxed) {
                         let _ = writeln!(
                             err,
                             "note: call backtrace::enable_backtrace with 'PrintFormat::Short/Full' for a backtrace."


### PR DESCRIPTION
https://github.com/apache/incubator-teaclave-sgx-sdk/blob/780dc8999477244d8ff1e6f418321adbec51ee58/sgx_tstd/src/panicking.rs#L288
I think the use of ordering here is irregular, FIRST_PANIC is used here for Signals in a multi-threaded environment, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.