### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/dockerfile/Dockerfile.1804.nightly
+++ b/dockerfile/Dockerfile.1804.nightly
@@ -11,13 +11,13 @@ ENV BINUTILS_DIST="ubuntu18.04"
 ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/lib
 ENV LD_RUN_PATH=/usr/lib:/usr/local/lib
 
-ADD 02_binutils.sh /root
+COPY 02_binutils.sh /root
 RUN bash /root/02_binutils.sh
 
 ENV SDK_DIST="INTEL_BUILT"
 ENV SDK_URL="https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.17.101.1.bin"
 #ENV SDK_DIST="SELF_BUILT"
-ADD 03_sdk.sh /root
+COPY 03_sdk.sh /root
 RUN bash /root/03_sdk.sh
     
 # Sixth, PSW
@@ -26,13 +26,13 @@ ENV CODENAME        bionic
 ENV VERSION         2.17.100.3-bionic1
 ENV DCAP_VERSION    1.14.100.3-bionic1
 
-ADD 04_psw.sh /root
+COPY 04_psw.sh /root
 RUN bash /root/04_psw.sh
 
 # Seventh, Rust
 
 ENV rust_toolchain  nightly-2022-02-23
-ADD 05_rust.sh /root
+COPY 05_rust.sh /root
 RUN bash /root/05_rust.sh
 
 ENV DEBIAN_FRONTEND=


### PR DESCRIPTION
Hi!
The Dockerfile placed at "dockerfile/Dockerfile.1804.nightly" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance