### PR TITLE
Remove cargo doc warnings

### DIFF
--- a/sgx_rand/src/chacha.rs
+++ b/sgx_rand/src/chacha.rs
@@ -24,14 +24,14 @@ const KEY_WORDS: usize = 8; // 8 words for the 256-bit key
 const STATE_WORDS: usize = 16;
 const CHACHA_ROUNDS: u32 = 20; // Cryptographically secure from 8 upwards as of this writing
 
-/// A random number generator that uses the ChaCha20 algorithm [1].
+/// A random number generator that uses the ChaCha20 algorithm \[1\].
 ///
 /// The ChaCha algorithm is widely accepted as suitable for
 /// cryptographic purposes, but this implementation has not been
 /// verified as such. Prefer a generator like `OsRng` that defers to
 /// the operating system for cases that need high security.
 ///
-/// [1]: D. J. Bernstein, [*ChaCha, a variant of
+/// \[1\]: D. J. Bernstein, [*ChaCha, a variant of
 /// Salsa20*](http://cr.yp.to/chacha.html)
 #[derive(Copy, Clone, Debug)]
 pub struct ChaChaRng {

--- a/sgx_rand/src/distributions/exponential.rs
+++ b/sgx_rand/src/distributions/exponential.rs
@@ -24,11 +24,11 @@ use crate::{Rand, Rng};
 ///
 /// See `Exp` for the general exponential distribution.
 ///
-/// Implemented via the ZIGNOR variant[1] of the Ziggurat method. The
+/// Implemented via the ZIGNOR variant\[1\] of the Ziggurat method. The
 /// exact description in the paper was adjusted to use tables for the
 /// exponential distribution rather than normal.
 ///
-/// [1]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to
+/// \[1\]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to
 /// Generate Normal Random
 /// Samples*](http://www.doornik.com/research/ziggurat.pdf). Nuffield
 /// College, Oxford

--- a/sgx_rand/src/distributions/gamma.rs
+++ b/sgx_rand/src/distributions/gamma.rs
@@ -35,9 +35,9 @@ use crate::{Open01, Rng};
 /// where `Γ` is the Gamma function, `k` is the shape and `θ` is the
 /// scale and both `k` and `θ` are strictly positive.
 ///
-/// The algorithm used is that described by Marsaglia & Tsang 2000[1],
+/// The algorithm used is that described by Marsaglia & Tsang 2000\[1\],
 /// falling back to directly sampling from an Exponential for `shape
-/// == 1`, and using the boosting technique described in [1] for
+/// == 1`, and using the boosting technique described in \[1\] for
 /// `shape < 1`.
 ///
 /// # Example
@@ -50,7 +50,7 @@ use crate::{Open01, Rng};
 /// println!("{} is from a Gamma(2, 5) distribution", v);
 /// ```
 ///
-/// [1]: George Marsaglia and Wai Wan Tsang. 2000. "A Simple Method
+/// \[1\]: George Marsaglia and Wai Wan Tsang. 2000. "A Simple Method
 /// for Generating Gamma Variables" *ACM Trans. Math. Softw.* 26, 3
 /// (September 2000),
 /// 363-372. DOI:[10.1145/358407.358414](http://doi.acm.org/10.1145/358407.358414)

--- a/sgx_rand/src/distributions/normal.rs
+++ b/sgx_rand/src/distributions/normal.rs
@@ -24,9 +24,9 @@ use crate::{Open01, Rand, Rng};
 ///
 /// See `Normal` for the general normal distribution.
 ///
-/// Implemented via the ZIGNOR variant[1] of the Ziggurat method.
+/// Implemented via the ZIGNOR variant\[1\] of the Ziggurat method.
 ///
-/// [1]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to
+/// \[1\]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to
 /// Generate Normal Random
 /// Samples*](http://www.doornik.com/research/ziggurat.pdf). Nuffield
 /// College, Oxford

--- a/sgx_rand/src/isaac.rs
+++ b/sgx_rand/src/isaac.rs
@@ -30,14 +30,14 @@ const RAND_SIZE_LEN: usize = 8;
 const RAND_SIZE: u32 = 1 << RAND_SIZE_LEN;
 const RAND_SIZE_USIZE: usize = 1 << RAND_SIZE_LEN;
 
-/// A random number generator that uses the ISAAC algorithm[1].
+/// A random number generator that uses the ISAAC algorithm\[1\].
 ///
 /// The ISAAC algorithm is generally accepted as suitable for
 /// cryptographic purposes, but this implementation has not be
 /// verified as such. Prefer a generator like `OsRng` that defers to
 /// the operating system for cases that need high security.
 ///
-/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
+/// \[1\]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
 /// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
 #[derive(Copy)]
 pub struct IsaacRng {
@@ -309,7 +309,7 @@ impl fmt::Debug for IsaacRng {
 const RAND_SIZE_64_LEN: usize = 8;
 const RAND_SIZE_64: usize = 1 << RAND_SIZE_64_LEN;
 
-/// A random number generator that uses ISAAC-64[1], the 64-bit
+/// A random number generator that uses ISAAC-64\[1\], the 64-bit
 /// variant of the ISAAC algorithm.
 ///
 /// The ISAAC algorithm is generally accepted as suitable for
@@ -317,7 +317,7 @@ const RAND_SIZE_64: usize = 1 << RAND_SIZE_64_LEN;
 /// verified as such. Prefer a generator like `OsRng` that defers to
 /// the operating system for cases that need high security.
 ///
-/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
+/// \[1\]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
 /// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
 #[derive(Copy)]
 pub struct Isaac64Rng {

--- a/sgx_rand/src/lib.rs
+++ b/sgx_rand/src/lib.rs
@@ -144,8 +144,8 @@ pub trait Rng {
     /// See:
     /// A PRNG specialized in double precision floating point numbers using
     /// an affine transition
-    /// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/dSFMT.pdf
-    /// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-slide-e.pdf
+    /// <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/dSFMT.pdf>
+    /// <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-slide-e.pdf>
     ///
     /// By default this is implemented in terms of `next_u32`, but a
     /// random number generator which can generate numbers satisfying
@@ -535,14 +535,14 @@ pub trait SeedableRng<Seed>: Rng {
     fn from_seed(seed: Seed) -> Self;
 }
 
-/// An Xorshift[1] random number
+/// An Xorshift\[1\] random number
 /// generator.
 ///
 /// The Xorshift algorithm is not suitable for cryptographic purposes
 /// but is very fast. If you do not know for sure that it fits your
 /// requirements, use a more secure one such as `IsaacRng` or `RdRand`.
 ///
-/// [1]: Marsaglia, George (July 2003). ["Xorshift
+/// \[1\]: Marsaglia, George (July 2003). ["Xorshift
 /// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
 /// Statistical Software*. Vol. 8 (Issue 14).
 #[allow(missing_copy_implementations)]


### PR DESCRIPTION
The original logs are:
```
warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/chacha.rs:27:65
   |
27 | /// A random number generator that uses the ChaCha20 algorithm [1].
   |                                                                 ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/chacha.rs:34:6
   |
34 | /// [1]: D. J. Bernstein, [*ChaCha, a variant of
   |      ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/exponential.rs:27:40
   |
27 | /// Implemented via the ZIGNOR variant[1] of the Ziggurat method. The
   |                                        ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/exponential.rs:31:6
   |
31 | /// [1]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to
   |      ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/gamma.rs:38:68
   |
38 | /// The algorithm used is that described by Marsaglia & Tsang 2000[1],
   |                                                                    ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/gamma.rs:40:59
   |
40 | /// == 1`, and using the boosting technique described in [1] for
   |                                                           ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/gamma.rs:53:6
   |
53 | /// [1]: George Marsaglia and Wai Wan Tsang. 2000. "A Simple Method
   |      ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/normal.rs:27:40
   |
27 | /// Implemented via the ZIGNOR variant[1] of the Ziggurat method.
   |                                        ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/distributions/normal.rs:29:6
   |
29 | /// [1]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to
   |      ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/isaac.rs:33:61
   |
33 | /// A random number generator that uses the ISAAC algorithm[1].
   |                                                             ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
  --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/isaac.rs:40:6
   |
40 | /// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
   |      ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
   --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/isaac.rs:312:50
    |
312 | /// A random number generator that uses ISAAC-64[1], the 64-bit
    |                                                  ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
   --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/isaac.rs:320:6
    |
320 | /// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
    |      ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
   --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/lib.rs:538:17
    |
538 | /// An Xorshift[1] random number
    |                 ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
   --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/lib.rs:545:6
    |
545 | /// [1]: Marsaglia, George (July 2003). ["Xorshift
    |      ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: this URL is not a hyperlink
   --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/lib.rs:147:9
    |
147 |     /// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/dSFMT.pdf
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/dSFMT.pdf>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: this URL is not a hyperlink
   --> /root/sunhe/incubator-teaclave/third_party/rust-sgx-sdk/sgx_rand/src/lib.rs:148:9
    |
148 |     /// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-slide-e.pdf
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-slide-e.pdf>`
    |
    = note: bare URLs are not automatically turned into clickable links


```