### PR TITLE
Implement Send and Sync for SgxFile

### DIFF
--- a/sgx_protected_fs/tfs/src/fs.rs
+++ b/sgx_protected_fs/tfs/src/fs.rs
@@ -56,6 +56,9 @@ pub struct SgxFile {
     inner: fs_imp::SgxFile,
 }
 
+unsafe impl Send for SgxFile {}
+unsafe impl Sync for SgxFile {}
+
 /// Read the entire contents of a file into a bytes vector.
 #[cfg(feature = "tfs")]
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {


### PR DESCRIPTION
std::fs::File has the implementaions of those two traits. If SgxFile had the same implementation, it would be convenient for developers to replace File with SgxFile where those implementations are needed during Rust crate porting to SGX enclave.