### PR TITLE
Fune-tune the Ordering for all the atomics

### DIFF
--- a/sgx_tstd/hashbrown/benches/bench.rs
+++ b/sgx_tstd/hashbrown/benches/bench.rs
@@ -45,6 +45,10 @@ impl Iterator for RandomKeys {
 
 // Just an arbitrary side effect to make the maps not shortcircuit to the non-dropping path
 // when dropping maps/entries (most real world usages likely have drop in the key or value)
+//
+// Note about memory ordering:
+// Here SIDE_EFFECT does't synchronize with other varibales, it is just a counting
+// variable, using ‘Relaxed’ is enough to ensure the correctness of the program.
 lazy_static::lazy_static! {
     static ref SIDE_EFFECT: AtomicUsize = AtomicUsize::new(0);
 }

--- a/sgx_tstd/src/alloc.rs
+++ b/sgx_tstd/src/alloc.rs
@@ -78,6 +78,11 @@ pub use alloc_crate::alloc::*;
 
 pub use sgx_alloc::System;
 
+/// Note about memory ordering:
+/// 
+/// HOOK here is used as an allocation error handler, which needs to make sure the 
+/// memory contents are initialized before storing the memory address to the HOOK.
+/// So using Release/Acquire is enough.
 static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
 /// Registers a custom allocation error hook, replacing any that was previously registered.
@@ -106,7 +111,7 @@ static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 /// set_alloc_error_hook(custom_alloc_error_hook);
 /// ```
 pub fn set_alloc_error_hook(hook: fn(Layout)) {
-    HOOK.store(hook as *mut (), Ordering::SeqCst);
+    HOOK.store(hook as *mut (), Ordering::Release);
 }
 
 /// Unregisters the current allocation error hook, returning it.
@@ -115,7 +120,7 @@ pub fn set_alloc_error_hook(hook: fn(Layout)) {
 ///
 /// If no custom hook is registered, the default hook will be returned.
 pub fn take_alloc_error_hook() -> fn(Layout) {
-    let hook = HOOK.swap(ptr::null_mut(), Ordering::SeqCst);
+    let hook = HOOK.swap(ptr::null_mut(), Ordering::AcqRel);
     if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } }
 }
 
@@ -137,7 +142,7 @@ fn default_alloc_error_hook(layout: Layout) {
 #[doc(hidden)]
 #[alloc_error_handler]
 pub fn rust_oom(layout: Layout) -> ! {
-    let hook = HOOK.load(Ordering::SeqCst);
+    let hook = HOOK.load(Ordering::Acquire);
     let hook: fn(Layout) =
         if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } };
     hook(layout);

--- a/sgx_tstd/src/panic.rs
+++ b/sgx_tstd/src/panic.rs
@@ -248,6 +248,9 @@ impl BacktraceStyle {
 // that backtrace.
 //
 // Internally stores equivalent of an Option<BacktraceStyle>.
+//
+// Here SHOULD_CAPTURE is just used as a shared variety in multithreaded environment, 
+// and doesn't synchronize with other variables. Using relaxed here is enough.
 #[cfg(feature = "backtrace")]
 static SHOULD_CAPTURE: AtomicUsize = AtomicUsize::new(0);
 
@@ -258,7 +261,7 @@ static SHOULD_CAPTURE: AtomicUsize = AtomicUsize::new(0);
 /// environment variable; see the details in [`get_backtrace_style`].
 #[cfg(feature = "backtrace")]
 pub fn set_backtrace_style(style: BacktraceStyle) {
-    SHOULD_CAPTURE.store(style.as_usize(), Ordering::Release);
+    SHOULD_CAPTURE.store(style.as_usize(), Ordering::Relaxed);
 }
 
 /// Checks whether the standard library's panic hook will capture and print a
@@ -284,5 +287,5 @@ pub fn set_backtrace_style(style: BacktraceStyle) {
 /// Returns `None` if backtraces aren't currently supported.
 #[cfg(feature = "backtrace")]
 pub fn get_backtrace_style() -> Option<BacktraceStyle> {
-    BacktraceStyle::from_usize(SHOULD_CAPTURE.load(Ordering::Acquire))
+    BacktraceStyle::from_usize(SHOULD_CAPTURE.load(Ordering::Relaxed))
 }

--- a/sgx_tstd/src/panicking.rs
+++ b/sgx_tstd/src/panicking.rs
@@ -275,6 +275,10 @@ fn default_hook(info: &PanicInfo<'_>) {
 
         #[cfg(feature = "backtrace")]
         {
+            // Note about memory ordering:
+            // Here FIRST_PANIC just using in this function. the only read and load
+            // operation just do in line 292, and it doesn't sychornized with other 
+            // varieties, using relaxed is enough to ensure safety here.
             static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
 
             match backtrace {
@@ -285,7 +289,7 @@ fn default_hook(info: &PanicInfo<'_>) {
                     drop(backtrace::print(err, crate::sys::backtrace::PrintFmt::Full))
                 }
                 Some(BacktraceStyle::Off) => {
-                    if FIRST_PANIC.swap(false, Ordering::SeqCst) {
+                    if FIRST_PANIC.swap(false, Ordering::Relaxed) {
                         let _ = writeln!(
                             err,
                             "note: call backtrace::enable_backtrace with 'PrintFormat::Short/Full' for a backtrace."


### PR DESCRIPTION
With the help of the static detector I wrote and my long-term research understanding of atomic:ordering, I made fine-grained modifications to the use of atomic::order in the teaclave source code and added relevant comments to address thread performance and security issues caused by sorting in specific processors.