### PR TITLE
Fix panic with misaligned pointer dereference in `u_sgxfs_open_ocall`

### DIFF
--- a/sgx_urts/src/ocall/sgxfile.rs
+++ b/sgx_urts/src/ocall/sgxfile.rs
@@ -53,13 +53,14 @@ pub unsafe extern "C" fn u_sgxfs_open_ocall(
             return ptr::null_mut();
         }
     };
-    *size = match file.size() {
+    let sz = match file.size() {
         Ok(size) => size,
         Err(errno) => {
             set_error(error, errno);
             return ptr::null_mut();
         }
     };
+    unsafe { size.write_unaligned(sz) };
 
     file.into_raw_stream() as *mut c_void
 }


### PR DESCRIPTION
When a program calls `sgx_tprotected_fs::write`, the following error occurs during the execution:

```
thread 'main' panicked at rust-sgx-sdk/sgx_urts/src/ocall/sgxfile.rs:56:5:
misaligned pointer dereference: address must be a multiple of 0x8 but is 0x7ffeb7fdbd25
```

To avoid this panic happening while writing a value into a variable on an unaligned memory region, we can use an unsafe method `write_unaligned`.

I checked this patch works well with my own program based on Automata SGX SDK which is based on the customized version of Teaclave SGX SDK with this patch.