### PR TITLE
Remove erroring feature flag in `rustlib/proc_macro`

### DIFF
--- a/rustlib/proc_macro/src/lib.rs
+++ b/rustlib/proc_macro/src/lib.rs
@@ -27,7 +27,6 @@
 #![feature(maybe_uninit_write_slice)]
 #![feature(negative_impls)]
 #![feature(new_uninit)]
-#![feature(restricted_std)]
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]
 #![feature(strict_provenance)]

--- a/rustlib/x86_64-unknown-linux-sgx.json
+++ b/rustlib/x86_64-unknown-linux-sgx.json
@@ -37,7 +37,7 @@
     "memory",
     "thread"
   ],
-  "target-c-int-width": "u16",
+  "target-c-int-width": "32u16",
   "target-endian": "little",
   "target-family": "unix",
   "target-pointer-width": "64",

--- a/rustlib/x86_64-unknown-linux-sgx.json
+++ b/rustlib/x86_64-unknown-linux-sgx.json
@@ -38,8 +38,8 @@
     "thread"
   ],
   "target-c-int-width": 32,
+  "target-pointer-width": "64",
   "target-endian": "little",
   "target-family": "unix",
-  "target-pointer-width": 64,
   "vendor": "teaclave"
 }

--- a/rustlib/x86_64-unknown-linux-sgx.json
+++ b/rustlib/x86_64-unknown-linux-sgx.json
@@ -37,7 +37,7 @@
     "memory",
     "thread"
   ],
-  "target-c-int-width": "32u16",
+  "target-c-int-width": "32",
   "target-endian": "little",
   "target-family": "unix",
   "target-pointer-width": "64",

--- a/rustlib/x86_64-unknown-linux-sgx.json
+++ b/rustlib/x86_64-unknown-linux-sgx.json
@@ -37,9 +37,9 @@
     "memory",
     "thread"
   ],
-  "target-c-int-width": "32",
+  "target-c-int-width": 32,
   "target-endian": "little",
   "target-family": "unix",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "vendor": "teaclave"
 }

--- a/rustlib/x86_64-unknown-linux-sgx.json
+++ b/rustlib/x86_64-unknown-linux-sgx.json
@@ -37,7 +37,7 @@
     "memory",
     "thread"
   ],
-  "target-c-int-width": "32",
+  "target-c-int-width": "u16",
   "target-endian": "little",
   "target-family": "unix",
   "target-pointer-width": "64",


### PR DESCRIPTION
Maybe this is not a PR but a question/discussion. To build rustlib/proc_macro on my machine, I have to remove `#[feature(restricted_std)]`. If this happens to others, this might want to be merged. A brief search on this feature didn't give me any hints on what it is. Why is it there in the first place?

My Rust version: `nightly-2025-09-13`